### PR TITLE
[NFC] Fix warning in RISCVVectorEmitter.cpp

### DIFF
--- a/clang/utils/TableGen/RISCVVectorEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVectorEmitter.cpp
@@ -404,7 +404,7 @@ void RISCVVectorEmitter::createHeader(raw_ostream &OS) {
         }
         else
           OS << type->getTypeName() << " op" << count << ",";
-          count++;
+        count++;
       }
       OS <<"size_t vl) { vsetvl_e" << def->getSuffix().substr(1) <<"(vl); return ";
       OS << def->getName() << def->getInfix() <<"_"<< def->getSuffix();


### PR DESCRIPTION
The incorrect indent is causing the following warning:
```
warning: this 'else' clause does not guard... [-Wmisleading-indentation]
```