### PR TITLE
Add some p-ext intrinsic support

### DIFF
--- a/clang/include/clang/Basic/BuiltinsRISCV.def
+++ b/clang/include/clang/Basic/BuiltinsRISCV.def
@@ -130,6 +130,9 @@ TARGET_BUILTIN(__rv_add8, "ULiULiULi", "", "experimental-p")
 // add16
 TARGET_BUILTIN(__rv_add16, "ULiULiULi", "", "experimental-p")
 
+// add32
+TARGET_BUILTIN(__rv_add32, "ULiULiULi", "", "experimental-p")
+
 // ave
 TARGET_BUILTIN(__rv_ave, "SLiSLiSLi", "", "experimental-p")
 
@@ -166,8 +169,14 @@ TARGET_BUILTIN(__rv_cmpeq16, "ULiULiULi", "", "experimental-p")
 // cras16
 TARGET_BUILTIN(__rv_cras16, "ULiULiULi", "", "experimental-p")
 
+// cras32
+TARGET_BUILTIN(__rv_cras32, "ULiULiULi", "", "experimental-p")
+
 // crsa16
 TARGET_BUILTIN(__rv_crsa16, "ULiULiULi", "", "experimental-p")
+
+// crsa32
+TARGET_BUILTIN(__rv_crsa32, "ULiULiULi", "", "experimental-p")
 
 // insb
 TARGET_BUILTIN(__rv_insb, "ULiULiULiULi", "", "experimental-p")
@@ -187,6 +196,9 @@ TARGET_BUILTIN(__rv_kadd8, "ULiULiULi", "", "experimental-p")
 // kadd16
 TARGET_BUILTIN(__rv_kadd16, "ULiULiULi", "", "experimental-p")
 
+// kadd32
+TARGET_BUILTIN(__rv_kadd32, "ULiULiULi", "", "experimental-p")
+
 // kaddh
 TARGET_BUILTIN(__rv_kaddh, "LiLiLi", "", "experimental-p")
 
@@ -196,8 +208,14 @@ TARGET_BUILTIN(__rv_kaddw, "LiLiLi", "", "experimental-p")
 // kcras16
 TARGET_BUILTIN(__rv_kcras16, "ULiULiULi", "", "experimental-p")
 
+// kcras32
+TARGET_BUILTIN(__rv_kcras32, "ULiULiULi", "", "experimental-p")
+
 // kcrsa16
 TARGET_BUILTIN(__rv_kcrsa16, "ULiULiULi", "", "experimental-p")
+
+// kcrsa32
+TARGET_BUILTIN(__rv_kcrsa32, "ULiULiULi", "", "experimental-p")
 
 // kdmbb
 TARGET_BUILTIN(__rv_kdmbb, "LiULiULi", "", "experimental-p")
@@ -206,12 +224,26 @@ TARGET_BUILTIN(__rv_kdmbt, "LiULiULi", "", "experimental-p")
 // kdmtt
 TARGET_BUILTIN(__rv_kdmtt, "LiULiULi", "", "experimental-p")
 
+// kdmbb16
+TARGET_BUILTIN(__rv_kdmbb16, "LiULiULi", "", "experimental-p")
+// kdmbt16
+TARGET_BUILTIN(__rv_kdmbt16, "LiULiULi", "", "experimental-p")
+// kdmtt16
+TARGET_BUILTIN(__rv_kdmtt16, "LiULiULi", "", "experimental-p")
+
 // kdmabb
 TARGET_BUILTIN(__rv_kdmabb, "LiLiULiULi", "", "experimental-p")
 // kdmabt
 TARGET_BUILTIN(__rv_kdmabt, "LiLiULiULi", "", "experimental-p")
 // kdmatt
 TARGET_BUILTIN(__rv_kdmatt, "LiLiULiULi", "", "experimental-p")
+
+// kdmabb16
+TARGET_BUILTIN(__rv_kdmabb16, "LiLiULiULi", "", "experimental-p")
+// kdmabt16
+TARGET_BUILTIN(__rv_kdmabt16, "LiLiULiULi", "", "experimental-p")
+// kdmatt16
+TARGET_BUILTIN(__rv_kdmatt16, "LiLiULiULi", "", "experimental-p")
 
 // khm8
 TARGET_BUILTIN(__rv_khm8, "ULiULiULi", "", "experimental-p")
@@ -229,6 +261,13 @@ TARGET_BUILTIN(__rv_khmbb, "LiULiULi", "", "experimental-p")
 TARGET_BUILTIN(__rv_khmbt, "LiULiULi", "", "experimental-p")
 // khmtt
 TARGET_BUILTIN(__rv_khmtt, "LiULiULi", "", "experimental-p")
+
+// khmbb16
+TARGET_BUILTIN(__rv_khmbb16, "LiULiULi", "", "experimental-p")
+// khmbt16
+TARGET_BUILTIN(__rv_khmbt16, "LiULiULi", "", "experimental-p")
+// khmtt16
+TARGET_BUILTIN(__rv_khmtt16, "LiULiULi", "", "experimental-p")
 
 // kmabb
 TARGET_BUILTIN(__rv_kmabb, "LiLiULiULi", "", "experimental-p")
@@ -326,14 +365,23 @@ TARGET_BUILTIN(__rv_kslraw_u, "LiLiLi", "", "experimental-p")
 // kstas16
 TARGET_BUILTIN(__rv_kstas16, "ULiULiULi", "", "experimental-p")
 
+// kstas32
+TARGET_BUILTIN(__rv_kstas32, "ULiULiULi", "", "experimental-p")
+
 // kstsa16
 TARGET_BUILTIN(__rv_kstsa16, "ULiULiULi", "", "experimental-p")
+
+// kstsa32
+TARGET_BUILTIN(__rv_kstsa32, "ULiULiULi", "", "experimental-p")
 
 // ksub8
 TARGET_BUILTIN(__rv_ksub8, "ULiULiULi", "", "experimental-p")
 
 // ksub16
 TARGET_BUILTIN(__rv_ksub16, "ULiULiULi", "", "experimental-p")
+
+// ksub32
+TARGET_BUILTIN(__rv_ksub32, "ULiULiULi", "", "experimental-p")
 
 // ksubh
 TARGET_BUILTIN(__rv_ksubh, "LiLiLi", "", "experimental-p")
@@ -373,26 +421,44 @@ TARGET_BUILTIN(__rv_radd8, "ULiULiULi", "", "experimental-p")
 // radd16
 TARGET_BUILTIN(__rv_radd16, "ULiULiULi", "", "experimental-p")
 
+// radd32
+TARGET_BUILTIN(__rv_radd32, "ULiULiULi", "", "experimental-p")
+
 // raddw
 TARGET_BUILTIN(__rv_raddw, "LiLiLi", "", "experimental-p")
 
 // rcras16
 TARGET_BUILTIN(__rv_rcras16, "ULiULiULi", "", "experimental-p")
 
+// rcras32
+TARGET_BUILTIN(__rv_rcras32, "ULiULiULi", "", "experimental-p")
+
 // rcrsa16
 TARGET_BUILTIN(__rv_rcrsa16, "ULiULiULi", "", "experimental-p")
+
+// rcrsa32
+TARGET_BUILTIN(__rv_rcrsa32, "ULiULiULi", "", "experimental-p")
 
 // rstas16
 TARGET_BUILTIN(__rv_rstas16, "ULiULiULi", "", "experimental-p")
 
+// rstas32
+TARGET_BUILTIN(__rv_rstas32, "ULiULiULi", "", "experimental-p")
+
 // rstsa16
 TARGET_BUILTIN(__rv_rstsa16, "ULiULiULi", "", "experimental-p")
+
+// rstsa32
+TARGET_BUILTIN(__rv_rstsa32, "ULiULiULi", "", "experimental-p")
 
 // rsub8
 TARGET_BUILTIN(__rv_rsub8, "ULiULiULi", "", "experimental-p")
 
 // rsub16
 TARGET_BUILTIN(__rv_rsub16, "ULiULiULi", "", "experimental-p")
+
+// rsub32
+TARGET_BUILTIN(__rv_rsub32, "ULiULiULi", "", "experimental-p")
 
 // rsubw
 TARGET_BUILTIN(__rv_rsubw, "LiLiLi", "", "experimental-p")
@@ -438,10 +504,21 @@ TARGET_BUILTIN(__rv_smax16, "ULiULiULi", "", "experimental-p")
 
 // smbb16
 TARGET_BUILTIN(__rv_smbb16, "LiULiULi", "", "experimental-p")
+
+//smbb32
+TARGET_BUILTIN(__rv_smbb32, "LiLiLi", "", "experimental-p")
+
 // smbt16
 TARGET_BUILTIN(__rv_smbt16, "LiULiULi", "", "experimental-p")
+
+// smbt32
+TARGET_BUILTIN(__rv_smbt32, "LiLiLi", "", "experimental-p")
+
 // smtt16
 TARGET_BUILTIN(__rv_smtt16, "LiULiULi", "", "experimental-p")
+
+// smtt32
+TARGET_BUILTIN(__rv_smtt32, "LiLiLi", "", "experimental-p")
 
 // smds
 TARGET_BUILTIN(__rv_smds, "LiULiULi", "", "experimental-p")
@@ -497,14 +574,23 @@ TARGET_BUILTIN(__rv_srl16_u, "ULiULiULi", "", "experimental-p")
 // stas16
 TARGET_BUILTIN(__rv_stas16, "ULiULiULi", "", "experimental-p")
 
+// stas32
+TARGET_BUILTIN(__rv_stas32, "ULiULiULi", "", "experimental-p")
+
 // stsa16
 TARGET_BUILTIN(__rv_stsa16, "ULiULiULi", "", "experimental-p")
+
+// stsa32
+TARGET_BUILTIN(__rv_stsa32, "ULiULiULi", "", "experimental-p")
 
 // sub8
 TARGET_BUILTIN(__rv_sub8, "ULiULiULi", "", "experimental-p")
 
 // sub16
 TARGET_BUILTIN(__rv_sub16, "ULiULiULi", "", "experimental-p")
+
+// sub32
+TARGET_BUILTIN(__rv_sub32, "ULiULiULi", "", "experimental-p")
 
 // sunpkd810
 TARGET_BUILTIN(__rv_sunpkd810, "ULiULi", "", "experimental-p")
@@ -550,6 +636,9 @@ TARGET_BUILTIN(__rv_ukadd8, "ULiULiULi", "", "experimental-p")
 // ukadd16
 TARGET_BUILTIN(__rv_ukadd16, "ULiULiULi", "", "experimental-p")
 
+// ukadd32
+TARGET_BUILTIN(__rv_ukadd32, "ULiULiULi", "", "experimental-p")
+
 // ukaddh
 TARGET_BUILTIN(__rv_ukaddh, "ULiULiULi", "", "experimental-p")
 
@@ -559,20 +648,35 @@ TARGET_BUILTIN(__rv_ukaddw, "ULiULiULi", "", "experimental-p")
 // ukcras16
 TARGET_BUILTIN(__rv_ukcras16, "ULiULiULi", "", "experimental-p")
 
+// ukcras32
+TARGET_BUILTIN(__rv_ukcras32, "ULiULiULi", "", "experimental-p")
+
 // ukcrsa16
 TARGET_BUILTIN(__rv_ukcrsa16, "ULiULiULi", "", "experimental-p")
+
+// ukcrsa32
+TARGET_BUILTIN(__rv_ukcrsa32, "ULiULiULi", "", "experimental-p")
 
 // ukstas16
 TARGET_BUILTIN(__rv_ukstas16, "ULiULiULi", "", "experimental-p")
 
+// ukstas32
+TARGET_BUILTIN(__rv_ukstas32, "ULiULiULi", "", "experimental-p")
+
 // ukstsa16
 TARGET_BUILTIN(__rv_ukstsa16, "ULiULiULi", "", "experimental-p")
+
+// ukstsa32
+TARGET_BUILTIN(__rv_ukstsa32, "ULiULiULi", "", "experimental-p")
 
 // uksub8
 TARGET_BUILTIN(__rv_uksub8, "ULiULiULi", "", "experimental-p")
 
 // uksub16
 TARGET_BUILTIN(__rv_uksub16, "ULiULiULi", "", "experimental-p")
+
+// uksub32
+TARGET_BUILTIN(__rv_uksub32, "ULiULiULi", "", "experimental-p")
 
 // uksubh
 TARGET_BUILTIN(__rv_uksubh, "LiLiLi", "", "experimental-p")
@@ -601,26 +705,44 @@ TARGET_BUILTIN(__rv_uradd8, "ULiULiULi", "", "experimental-p")
 // uradd16
 TARGET_BUILTIN(__rv_uradd16, "ULiULiULi", "", "experimental-p")
 
+// uradd32
+TARGET_BUILTIN(__rv_uradd32, "ULiULiULi", "", "experimental-p")
+
 // uraddw
 TARGET_BUILTIN(__rv_uraddw, "LiLiLi", "", "experimental-p")
 
 // urcras16
 TARGET_BUILTIN(__rv_urcras16, "ULiULiULi", "", "experimental-p")
 
+// urcras32
+TARGET_BUILTIN(__rv_urcras32, "ULiULiULi", "", "experimental-p")
+
 // urcrsa16
 TARGET_BUILTIN(__rv_urcrsa16, "ULiULiULi", "", "experimental-p")
+
+// urcrsa32
+TARGET_BUILTIN(__rv_urcrsa32, "ULiULiULi", "", "experimental-p")
 
 // urstas16
 TARGET_BUILTIN(__rv_urstas16, "ULiULiULi", "", "experimental-p")
 
+// urstas32
+TARGET_BUILTIN(__rv_urstas32, "ULiULiULi", "", "experimental-p")
+
 // urstsa16
 TARGET_BUILTIN(__rv_urstsa16, "ULiULiULi", "", "experimental-p")
+
+// urstsa32
+TARGET_BUILTIN(__rv_urstsa32, "ULiULiULi", "", "experimental-p")
 
 // ursub8
 TARGET_BUILTIN(__rv_ursub8, "ULiULiULi", "", "experimental-p")
 
 // ursub16
 TARGET_BUILTIN(__rv_ursub16, "ULiULiULi", "", "experimental-p")
+
+// ursub32
+TARGET_BUILTIN(__rv_ursub32, "ULiULiULi", "", "experimental-p")
 
 // ursubw
 TARGET_BUILTIN(__rv_ursubw, "LiLiLi", "", "experimental-p")

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -19230,6 +19230,7 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   // Intrinsic type is obtained from Ops[0].
   case RISCV::BI__rv_add8:
   case RISCV::BI__rv_add16:
+  case RISCV::BI__rv_add32:
   case RISCV::BI__rv_ave:
   case RISCV::BI__rv_bitrev:
   case RISCV::BI__rv_bpick:
@@ -19242,17 +19243,22 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__rv_cmpeq8:
   case RISCV::BI__rv_cmpeq16:
   case RISCV::BI__rv_cras16:
+  case RISCV::BI__rv_cras32:
   case RISCV::BI__rv_crsa16:
+  case RISCV::BI__rv_crsa32:
   case RISCV::BI__rv_insb:
   case RISCV::BI__rv_kabs8:
   case RISCV::BI__rv_kabs16:
   case RISCV::BI__rv_kabsw:
   case RISCV::BI__rv_kadd8:
   case RISCV::BI__rv_kadd16:
+  case RISCV::BI__rv_kadd32:
   case RISCV::BI__rv_kaddh:
   case RISCV::BI__rv_kaddw:
   case RISCV::BI__rv_kcras16:
+  case RISCV::BI__rv_kcras32:
   case RISCV::BI__rv_kcrsa16:
+  case RISCV::BI__rv_kcrsa32:
   case RISCV::BI__rv_khm8:
   case RISCV::BI__rv_khm16:
   case RISCV::BI__rv_khmx8:
@@ -19265,9 +19271,12 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__rv_kslraw:
   case RISCV::BI__rv_kslraw_u:
   case RISCV::BI__rv_kstas16:
+  case RISCV::BI__rv_kstas32:
   case RISCV::BI__rv_kstsa16:
+  case RISCV::BI__rv_kstsa32:
   case RISCV::BI__rv_ksub8:
   case RISCV::BI__rv_ksub16:
+  case RISCV::BI__rv_ksub32:
   case RISCV::BI__rv_ksubh:
   case RISCV::BI__rv_ksubw:
   case RISCV::BI__rv_kwmmul:
@@ -19280,13 +19289,19 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__rv_pktb16:
   case RISCV::BI__rv_radd8:
   case RISCV::BI__rv_radd16:
+  case RISCV::BI__rv_radd32:
   case RISCV::BI__rv_raddw:
   case RISCV::BI__rv_rcras16:
+  case RISCV::BI__rv_rcras32:
   case RISCV::BI__rv_rcrsa16:
+  case RISCV::BI__rv_rcrsa32:
   case RISCV::BI__rv_rstas16:
+  case RISCV::BI__rv_rstas32:
   case RISCV::BI__rv_rstsa16:
+  case RISCV::BI__rv_rstsa32:
   case RISCV::BI__rv_rsub8:
   case RISCV::BI__rv_rsub16:
+  case RISCV::BI__rv_rsub32:
   case RISCV::BI__rv_rsubw:
   case RISCV::BI__rv_scmple8:
   case RISCV::BI__rv_scmple16:
@@ -19294,14 +19309,20 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__rv_scmplt16:
   case RISCV::BI__rv_smax8:
   case RISCV::BI__rv_smax16:
+  case RISCV::BI__rv_smbb32:
+  case RISCV::BI__rv_smbt32:
+  case RISCV::BI__rv_smtt32:
   case RISCV::BI__rv_smin8:
   case RISCV::BI__rv_smin16:
   case RISCV::BI__rv_smmul:
   case RISCV::BI__rv_smmul_u:
   case RISCV::BI__rv_stas16:
+  case RISCV::BI__rv_stas32:
   case RISCV::BI__rv_stsa16:
+  case RISCV::BI__rv_stsa32:
   case RISCV::BI__rv_sub8:
   case RISCV::BI__rv_sub16:
+  case RISCV::BI__rv_sub32:
   case RISCV::BI__rv_swap8:
   case RISCV::BI__rv_swap16:
   case RISCV::BI__rv_ucmple8:
@@ -19310,14 +19331,20 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__rv_ucmplt16:
   case RISCV::BI__rv_ukadd8:
   case RISCV::BI__rv_ukadd16:
+  case RISCV::BI__rv_ukadd32:
   case RISCV::BI__rv_ukaddh:
   case RISCV::BI__rv_ukaddw:
   case RISCV::BI__rv_ukcras16:
+  case RISCV::BI__rv_ukcras32:
   case RISCV::BI__rv_ukcrsa16:
+  case RISCV::BI__rv_ukcrsa32:
   case RISCV::BI__rv_ukstas16:
+  case RISCV::BI__rv_ukstas32:
   case RISCV::BI__rv_ukstsa16:
+  case RISCV::BI__rv_ukstsa32:
   case RISCV::BI__rv_uksub8:
   case RISCV::BI__rv_uksub16:
+  case RISCV::BI__rv_uksub32:
   case RISCV::BI__rv_uksubh:
   case RISCV::BI__rv_uksubw:
   case RISCV::BI__rv_umax8:
@@ -19326,19 +19353,26 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__rv_umin16:
   case RISCV::BI__rv_uradd8:
   case RISCV::BI__rv_uradd16:
+  case RISCV::BI__rv_uradd32:
   case RISCV::BI__rv_uraddw:
   case RISCV::BI__rv_urcras16:
+  case RISCV::BI__rv_urcras32:
   case RISCV::BI__rv_urcrsa16:
+  case RISCV::BI__rv_urcrsa32:
   case RISCV::BI__rv_urstas16:
+  case RISCV::BI__rv_urstas32:
   case RISCV::BI__rv_urstsa16:
+  case RISCV::BI__rv_urstsa32:
   case RISCV::BI__rv_ursub8:
   case RISCV::BI__rv_ursub16:
+  case RISCV::BI__rv_ursub32:
   case RISCV::BI__rv_ursubw: {
     switch (BuiltinID) {
     default:
       llvm_unreachable("unexpected builtin ID");
       BUILTIN_ID(add8)
       BUILTIN_ID(add16)
+      BUILTIN_ID(add32)
       BUILTIN_ID(ave)
       BUILTIN_ID(bitrev)
       BUILTIN_ID(bpick)
@@ -19351,17 +19385,22 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
       BUILTIN_ID(cmpeq8)
       BUILTIN_ID(cmpeq16)
       BUILTIN_ID(cras16)
+      BUILTIN_ID(cras32)
       BUILTIN_ID(crsa16)
+      BUILTIN_ID(crsa32)
       BUILTIN_ID(insb)
       BUILTIN_ID(kabs8)
       BUILTIN_ID(kabs16)
       BUILTIN_ID(kabsw)
       BUILTIN_ID(kadd8)
       BUILTIN_ID(kadd16)
+      BUILTIN_ID(kadd32)
       BUILTIN_ID(kaddh)
       BUILTIN_ID(kaddw)
       BUILTIN_ID(kcras16)
+      BUILTIN_ID(kcras32)
       BUILTIN_ID(kcrsa16)
+      BUILTIN_ID(kcrsa32)
       BUILTIN_ID(khm8)
       BUILTIN_ID(khm16)
       BUILTIN_ID(khmx8)
@@ -19374,9 +19413,12 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
       BUILTIN_ID(kslraw)
       BUILTIN_ID(kslraw_u)
       BUILTIN_ID(kstas16)
+      BUILTIN_ID(kstas32)
       BUILTIN_ID(kstsa16)
+      BUILTIN_ID(kstsa32)
       BUILTIN_ID(ksub8)
       BUILTIN_ID(ksub16)
+      BUILTIN_ID(ksub32)
       BUILTIN_ID(ksubh)
       BUILTIN_ID(ksubw)
       BUILTIN_ID(kwmmul)
@@ -19389,13 +19431,19 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
       BUILTIN_ID(pktb16)
       BUILTIN_ID(radd8)
       BUILTIN_ID(radd16)
+      BUILTIN_ID(radd32)
       BUILTIN_ID(raddw)
       BUILTIN_ID(rcras16)
+      BUILTIN_ID(rcras32)
       BUILTIN_ID(rcrsa16)
+      BUILTIN_ID(rcrsa32)
       BUILTIN_ID(rstas16)
+      BUILTIN_ID(rstas32)
       BUILTIN_ID(rstsa16)
+      BUILTIN_ID(rstsa32)
       BUILTIN_ID(rsub8)
       BUILTIN_ID(rsub16)
+      BUILTIN_ID(rsub32)
       BUILTIN_ID(rsubw)
       BUILTIN_ID(scmple8)
       BUILTIN_ID(scmple16)
@@ -19403,14 +19451,20 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
       BUILTIN_ID(scmplt16)
       BUILTIN_ID(smax8)
       BUILTIN_ID(smax16)
+      BUILTIN_ID(smbb32)
+      BUILTIN_ID(smbt32)
+      BUILTIN_ID(smtt32)
       BUILTIN_ID(smin8)
       BUILTIN_ID(smin16)
       BUILTIN_ID(smmul)
       BUILTIN_ID(smmul_u)
       BUILTIN_ID(stas16)
+      BUILTIN_ID(stas32)
       BUILTIN_ID(stsa16)
+      BUILTIN_ID(stsa32)
       BUILTIN_ID(sub8)
       BUILTIN_ID(sub16)
+      BUILTIN_ID(sub32)
       BUILTIN_ID(swap8)
       BUILTIN_ID(swap16)
       BUILTIN_ID(ucmple8)
@@ -19419,14 +19473,20 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
       BUILTIN_ID(ucmplt16)
       BUILTIN_ID(ukadd8)
       BUILTIN_ID(ukadd16)
+      BUILTIN_ID(ukadd32)
       BUILTIN_ID(ukaddh)
       BUILTIN_ID(ukaddw)
       BUILTIN_ID(ukcras16)
+      BUILTIN_ID(ukcras32)
       BUILTIN_ID(ukcrsa16)
+      BUILTIN_ID(ukcrsa32)
       BUILTIN_ID(ukstas16)
+      BUILTIN_ID(ukstas32)
       BUILTIN_ID(ukstsa16)
+      BUILTIN_ID(ukstsa32)
       BUILTIN_ID(uksub8)
       BUILTIN_ID(uksub16)
+      BUILTIN_ID(uksub32)
       BUILTIN_ID(uksubh)
       BUILTIN_ID(uksubw)
       BUILTIN_ID(umax8)
@@ -19435,13 +19495,19 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
       BUILTIN_ID(umin16)
       BUILTIN_ID(uradd8)
       BUILTIN_ID(uradd16)
+      BUILTIN_ID(uradd32)
       BUILTIN_ID(uraddw)
       BUILTIN_ID(urcras16)
+      BUILTIN_ID(urcras32)
       BUILTIN_ID(urcrsa16)
+      BUILTIN_ID(urcrsa32)
       BUILTIN_ID(urstas16)
+      BUILTIN_ID(urstas32)
       BUILTIN_ID(urstsa16)
+      BUILTIN_ID(urstsa32)
       BUILTIN_ID(ursub8)
       BUILTIN_ID(ursub16)
+      BUILTIN_ID(ursub32)
       BUILTIN_ID(ursubw)
     }
 
@@ -19486,6 +19552,12 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__rv_khmbb:
   case RISCV::BI__rv_khmbt:
   case RISCV::BI__rv_khmtt:
+  case RISCV::BI__rv_kdmbb16:
+  case RISCV::BI__rv_kdmbt16:
+  case RISCV::BI__rv_kdmtt16:
+  case RISCV::BI__rv_khmbb16:
+  case RISCV::BI__rv_khmbt16:
+  case RISCV::BI__rv_khmtt16:
   case RISCV::BI__rv_kmda:
   case RISCV::BI__rv_kmxda:
   case RISCV::BI__rv_pbsad:
@@ -19504,6 +19576,12 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
       BUILTIN_ID(khmbb)
       BUILTIN_ID(khmbt)
       BUILTIN_ID(khmtt)
+      BUILTIN_ID(kdmbb16)
+      BUILTIN_ID(kdmbt16)
+      BUILTIN_ID(kdmtt16)
+      BUILTIN_ID(khmbb16)
+      BUILTIN_ID(khmbt16)
+      BUILTIN_ID(khmtt16)
       BUILTIN_ID(kmda)
       BUILTIN_ID(kmxda)
       BUILTIN_ID(pbsad)
@@ -19523,6 +19601,9 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
   case RISCV::BI__rv_kdmabb:
   case RISCV::BI__rv_kdmabt:
   case RISCV::BI__rv_kdmatt:
+  case RISCV::BI__rv_kdmabb16:
+  case RISCV::BI__rv_kdmabt16:
+  case RISCV::BI__rv_kdmatt16:
   case RISCV::BI__rv_kmabb:
   case RISCV::BI__rv_kmabt:
   case RISCV::BI__rv_kmatt:
@@ -19574,6 +19655,9 @@ Value *CodeGenFunction::EmitRISCVBuiltinExpr(unsigned BuiltinID,
       BUILTIN_ID(kdmabb)
       BUILTIN_ID(kdmabt)
       BUILTIN_ID(kdmatt)
+      BUILTIN_ID(kdmabb16)
+      BUILTIN_ID(kdmabt16)
+      BUILTIN_ID(kdmatt16)
       BUILTIN_ID(kmabb)
       BUILTIN_ID(kmabt)
       BUILTIN_ID(kmatt)

--- a/clang/test/CodeGen/RISCV/rvp-intrinsics/rv32p.c
+++ b/clang/test/CodeGen/RISCV/rvp-intrinsics/rv32p.c
@@ -620,6 +620,15 @@ unsigned long ksll8(unsigned long a, unsigned int b) {
   return __rv_ksll8(a, b);
 }
 
+// CHECK-RV32-LABEL: @kslli8(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.ksll8.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long kslli8(unsigned long a, unsigned int b) {
+  return __rv_ksll8(a, 1);
+}
+
 // CHECK-RV32-LABEL: @ksll16(
 // CHECK-RV32-NEXT:  entry:
 // CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.ksll16.i32.i32(i32 [[A:%.*]], i32 [[B:%.*]])
@@ -627,6 +636,15 @@ unsigned long ksll8(unsigned long a, unsigned int b) {
 //
 unsigned long ksll16(unsigned long a, unsigned int b) {
   return __rv_ksll16(a, b);
+}
+
+// CHECK-RV32-LABEL: @kslli16(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.ksll16.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long kslli16(unsigned long a, unsigned int b) {
+  return __rv_ksll16(a, 1);
 }
 
 // CHECK-RV32-LABEL: @kslra8(
@@ -989,6 +1007,15 @@ unsigned long sll8(unsigned long a, unsigned int b) {
   return __rv_sll8(a, b);
 }
 
+// CHECK-RV32-LABEL: @slli8(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.sll8.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long slli8(unsigned long a, unsigned int b) {
+  return __rv_sll8(a, 1);
+}
+
 // CHECK-RV32-LABEL: @sll16(
 // CHECK-RV32-NEXT:  entry:
 // CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.sll16.i32.i32(i32 [[A:%.*]], i32 [[B:%.*]])
@@ -996,6 +1023,15 @@ unsigned long sll8(unsigned long a, unsigned int b) {
 //
 unsigned long sll16(unsigned long a, unsigned int b) {
   return __rv_sll16(a, b);
+}
+
+// CHECK-RV32-LABEL: @slli16(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.sll16.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long slli16(unsigned long a, unsigned int b) {
+  return __rv_sll16(a, 1);
 }
 
 // CHECK-RV32-LABEL: @smaqa(
@@ -1178,6 +1214,15 @@ unsigned long sra8(unsigned long a, unsigned int b) {
   return __rv_sra8(a, b);
 }
 
+// CHECK-RV32-LABEL: @srai8(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.sra8.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long srai8(unsigned long a, unsigned int b) {
+  return __rv_sra8(a, 1);
+}
+
 // CHECK-RV32-LABEL: @sra8_u(
 // CHECK-RV32-NEXT:  entry:
 // CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.sra8.u.i32.i32(i32 [[A:%.*]], i32 [[B:%.*]])
@@ -1185,6 +1230,15 @@ unsigned long sra8(unsigned long a, unsigned int b) {
 //
 unsigned long sra8_u(unsigned long a, unsigned int b) {
   return __rv_sra8_u(a, b);
+}
+
+// CHECK-RV32-LABEL: @srai8_u(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.sra8.u.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long srai8_u(unsigned long a, unsigned int b) {
+  return __rv_sra8_u(a, 1);
 }
 
 // CHECK-RV32-LABEL: @sra16(
@@ -1196,6 +1250,16 @@ unsigned long sra16(unsigned long a, unsigned int b) {
   return __rv_sra16(a, b);
 }
 
+// CHECK-RV32-LABEL: @srai16(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.sra16.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long srai16(unsigned long a, unsigned int b) {
+  return __rv_sra16(a, 1);
+}
+
+
 // CHECK-RV32-LABEL: @sra16_u(
 // CHECK-RV32-NEXT:  entry:
 // CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.sra16.u.i32.i32(i32 [[A:%.*]], i32 [[B:%.*]])
@@ -1203,6 +1267,15 @@ unsigned long sra16(unsigned long a, unsigned int b) {
 //
 unsigned long sra16_u(unsigned long a, unsigned int b) {
   return __rv_sra16_u(a, b);
+}
+
+// CHECK-RV32-LABEL: @srai16_u(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.sra16.u.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long srai16_u(unsigned long a, unsigned int b) {
+  return __rv_sra16_u(a, 1);
 }
 
 // CHECK-RV32-LABEL: @srl8(
@@ -1214,6 +1287,15 @@ unsigned long srl8(unsigned long a, unsigned int b) {
   return __rv_srl8(a, b);
 }
 
+// CHECK-RV32-LABEL: @srli8(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.srl8.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long srli8(unsigned long a, unsigned int b) {
+  return __rv_srl8(a, 1);
+}
+
 // CHECK-RV32-LABEL: @srl8_u(
 // CHECK-RV32-NEXT:  entry:
 // CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.srl8.u.i32.i32(i32 [[A:%.*]], i32 [[B:%.*]])
@@ -1221,6 +1303,15 @@ unsigned long srl8(unsigned long a, unsigned int b) {
 //
 unsigned long srl8_u(unsigned long a, unsigned int b) {
   return __rv_srl8_u(a, b);
+}
+
+// CHECK-RV32-LABEL: @srli8_u(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.srl8.u.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long srli8_u(unsigned long a, unsigned int b) {
+  return __rv_srl8_u(a, 1);
 }
 
 // CHECK-RV32-LABEL: @srl16(
@@ -1232,6 +1323,15 @@ unsigned long srl16(unsigned long a, unsigned int b) {
   return __rv_srl16(a, b);
 }
 
+// CHECK-RV32-LABEL: @srli16(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.srl16.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long srli16(unsigned long a, unsigned int b) {
+  return __rv_srl16(a, 1);
+}
+
 // CHECK-RV32-LABEL: @srl16_u(
 // CHECK-RV32-NEXT:  entry:
 // CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.srl16.u.i32.i32(i32 [[A:%.*]], i32 [[B:%.*]])
@@ -1239,6 +1339,15 @@ unsigned long srl16(unsigned long a, unsigned int b) {
 //
 unsigned long srl16_u(unsigned long a, unsigned int b) {
   return __rv_srl16_u(a, b);
+}
+
+// CHECK-RV32-LABEL: @srli16_u(
+// CHECK-RV32-NEXT:  entry:
+// CHECK-RV32-NEXT:    [[TMP0:%.*]] = tail call i32 @llvm.riscv.srl16.u.i32.i32(i32 [[A:%.*]], i32 1)
+// CHECK-RV32-NEXT:    ret i32 [[TMP0]]
+//
+unsigned long srli16_u(unsigned long a, unsigned int b) {
+  return __rv_srl16_u(a, 1);
 }
 
 // CHECK-RV32-LABEL: @stas16(

--- a/clang/test/CodeGen/RISCV/rvp-intrinsics/rv64p.c
+++ b/clang/test/CodeGen/RISCV/rvp-intrinsics/rv64p.c
@@ -36,6 +36,15 @@ unsigned long add16(unsigned long a, unsigned long b) {
   return __rv_add16(a, b);
 }
 
+// CHECK-RV64-LABEL: @add32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.add32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long add32(unsigned long a, unsigned long b) {
+  return __rv_add32(a, b);
+}
+
 // CHECK-RV64-LABEL: @ave(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ave.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -144,6 +153,15 @@ unsigned long cras16(unsigned long a, unsigned long b) {
   return __rv_cras16(a, b);
 }
 
+// CHECK-RV64-LABEL: @cras32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.cras32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long cras32(unsigned long a, unsigned long b) {
+  return __rv_cras32(a, b);
+}
+
 // CHECK-RV64-LABEL: @crsa16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.crsa16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -151,6 +169,15 @@ unsigned long cras16(unsigned long a, unsigned long b) {
 //
 unsigned long crsa16(unsigned long a, unsigned long b) {
   return __rv_crsa16(a, b);
+}
+
+// CHECK-RV64-LABEL: @crsa32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.crsa32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long crsa32(unsigned long a, unsigned long b) {
+  return __rv_crsa32(a, b);
 }
 
 // CHECK-RV64-LABEL: @insb(
@@ -207,6 +234,15 @@ unsigned long kadd16(unsigned long a, unsigned long b) {
   return __rv_kadd16(a, b);
 }
 
+// CHECK-RV64-LABEL: @kadd32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kadd32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long kadd32(unsigned long a, unsigned long b) {
+  return __rv_kadd32(a, b);
+}
+
 // CHECK-RV64-LABEL: @kaddh(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[CONV:%.*]] = sext i32 [[A:%.*]] to i64
@@ -238,6 +274,15 @@ unsigned long kcras16(unsigned long a, unsigned long b) {
   return __rv_kcras16(a, b);
 }
 
+// CHECK-RV64-LABEL: @kcras32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kcras32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long kcras32(unsigned long a, unsigned long b) {
+  return __rv_kcras32(a, b);
+}
+
 // CHECK-RV64-LABEL: @kcrsa16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kcrsa16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -245,6 +290,15 @@ unsigned long kcras16(unsigned long a, unsigned long b) {
 //
 unsigned long kcrsa16(unsigned long a, unsigned long b) {
   return __rv_kcrsa16(a, b);
+}
+
+// CHECK-RV64-LABEL: @kcrsa32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kcrsa32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long kcrsa32(unsigned long a, unsigned long b) {
+  return __rv_kcrsa32(a, b);
 }
 
 // CHECK-RV64-LABEL: @kdmbb(
@@ -280,6 +334,33 @@ long kdmtt(unsigned int a, unsigned int b) {
   return __rv_kdmtt(a, b);
 }
 
+// CHECK-RV64-LABEL: @kdmbb16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kdmbb16.i64.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long kdmbb16(unsigned long a, unsigned long b) {
+  return __rv_kdmbb16(a, b);
+}
+
+// CHECK-RV64-LABEL: @kdmbt16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kdmbt16.i64.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long kdmbt16(unsigned long a, unsigned long b) {
+  return __rv_kdmbt16(a, b);
+}
+
+// CHECK-RV64-LABEL: @kdmtt16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kdmtt16.i64.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long kdmtt16(unsigned long a, unsigned long b) {
+  return __rv_kdmtt16(a, b);
+}
+
 // CHECK-RV64-LABEL: @kdmabb(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[CONV:%.*]] = zext i32 [[A:%.*]] to i64
@@ -311,6 +392,33 @@ long kdmabt(long t, unsigned int a, unsigned int b) {
 //
 long kdmatt(long t, unsigned int a, unsigned int b) {
   return __rv_kdmatt(t, a, b);
+}
+
+// CHECK-RV64-LABEL: @kdmabb16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kdmabb16.i64.i64(i64 [[T:%.*]], i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long kdmabb16(long t, unsigned long a, unsigned long b) {
+  return __rv_kdmabb16(t, a, b);
+}
+
+// CHECK-RV64-LABEL: @kdmabt16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kdmabt16.i64.i64(i64 [[T:%.*]], i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long kdmabt16(long t, unsigned long a, unsigned long b) {
+  return __rv_kdmabt16(t, a, b);
+}
+
+// CHECK-RV64-LABEL: @kdmatt16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kdmatt16.i64.i64(i64 [[T:%.*]], i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long kdmatt16(long t, unsigned long a, unsigned long b) {
+  return __rv_kdmatt16(t, a, b);
 }
 
 // CHECK-RV64-LABEL: @khm8(
@@ -380,6 +488,33 @@ long khmbt(unsigned int a, unsigned int b) {
 //
 long khmtt(unsigned int a, unsigned int b) {
   return __rv_khmtt(a, b);
+}
+
+// CHECK-RV64-LABEL: @khmbb16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.khmbb16.i64.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long khmbb16(unsigned long a, unsigned long b) {
+  return __rv_khmbb16(a, b);
+}
+
+// CHECK-RV64-LABEL: @khmbt16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.khmbt16.i64.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long khmbt16(unsigned long a, unsigned long b) {
+  return __rv_khmbt16(a, b);
+}
+
+// CHECK-RV64-LABEL: @khmtt16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.khmtt16.i64.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long khmtt16(unsigned long a, unsigned long b) {
+  return __rv_khmtt16(a, b);
 }
 
 // CHECK-RV64-LABEL: @kmabb(
@@ -654,6 +789,15 @@ unsigned long ksll8(unsigned long a, unsigned int b) {
   return __rv_ksll8(a, b);
 }
 
+// CHECK-RV64-LABEL: @kslli8(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ksll8.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long kslli8(unsigned long a, unsigned int b) {
+  return __rv_ksll8(a, 1);
+}
+
 // CHECK-RV64-LABEL: @ksll16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[CONV:%.*]] = zext i32 [[B:%.*]] to i64
@@ -662,6 +806,15 @@ unsigned long ksll8(unsigned long a, unsigned int b) {
 //
 unsigned long ksll16(unsigned long a, unsigned int b) {
   return __rv_ksll16(a, b);
+}
+
+// CHECK-RV64-LABEL: @kslli16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ksll16.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long kslli16(unsigned long a, unsigned int b) {
+  return __rv_ksll16(a, 1);
 }
 
 // CHECK-RV64-LABEL: @kslra8(
@@ -735,6 +888,15 @@ unsigned long kstas16(unsigned long a, unsigned long b) {
   return __rv_kstas16(a, b);
 }
 
+// CHECK-RV64-LABEL: @kstas32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kstas32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long kstas32(unsigned long a, unsigned long b) {
+  return __rv_kstas32(a, b);
+}
+
 // CHECK-RV64-LABEL: @kstsa16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kstsa16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -742,6 +904,15 @@ unsigned long kstas16(unsigned long a, unsigned long b) {
 //
 unsigned long kstsa16(unsigned long a, unsigned long b) {
   return __rv_kstsa16(a, b);
+}
+
+// CHECK-RV64-LABEL: @kstsa32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.kstsa32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long kstsa32(unsigned long a, unsigned long b) {
+  return __rv_kstsa32(a, b);
 }
 
 // CHECK-RV64-LABEL: @ksub8(
@@ -760,6 +931,15 @@ unsigned long ksub8(unsigned long a, unsigned long b) {
 //
 unsigned long ksub16(unsigned long a, unsigned long b) {
   return __rv_ksub16(a, b);
+}
+
+// CHECK-RV64-LABEL: @ksub32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ksub32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long ksub32(unsigned long a, unsigned long b) {
+  return __rv_ksub32(a, b);
 }
 
 // CHECK-RV64-LABEL: @ksubh(
@@ -889,11 +1069,20 @@ unsigned long radd8(unsigned long a, unsigned long b) {
 
 // CHECK-RV64-LABEL: @radd16(
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.radd8.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.radd16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
 // CHECK-RV64-NEXT:    ret i64 [[TMP0]]
 //
 unsigned long radd16(unsigned long a, unsigned long b) {
-  return __rv_radd8(a, b);
+  return __rv_radd16(a, b);
+}
+
+// CHECK-RV64-LABEL: @radd32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.radd32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long radd32(unsigned long a, unsigned long b) {
+  return __rv_radd32(a, b);
 }
 
 // CHECK-RV64-LABEL: @raddw(
@@ -916,6 +1105,15 @@ unsigned long rcras16(unsigned long a, unsigned long b) {
   return __rv_rcras16(a, b);
 }
 
+// CHECK-RV64-LABEL: @rcras32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.rcras32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long rcras32(unsigned long a, unsigned long b) {
+  return __rv_rcras32(a, b);
+}
+
 // CHECK-RV64-LABEL: @rcrsa16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.rcrsa16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -923,6 +1121,15 @@ unsigned long rcras16(unsigned long a, unsigned long b) {
 //
 unsigned long rcrsa16(unsigned long a, unsigned long b) {
   return __rv_rcrsa16(a, b);
+}
+
+// CHECK-RV64-LABEL: @rcrsa32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.rcrsa32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long rcrsa32(unsigned long a, unsigned long b) {
+  return __rv_rcrsa32(a, b);
 }
 
 // CHECK-RV64-LABEL: @rstas16(
@@ -934,6 +1141,15 @@ unsigned long rstas16(unsigned long a, unsigned long b) {
   return __rv_rstas16(a, b);
 }
 
+// CHECK-RV64-LABEL: @rstas32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.rstas32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long rstas32(unsigned long a, unsigned long b) {
+  return __rv_rstas32(a, b);
+}
+
 // CHECK-RV64-LABEL: @rstsa16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.rstsa16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -941,6 +1157,15 @@ unsigned long rstas16(unsigned long a, unsigned long b) {
 //
 unsigned long rstsa16(unsigned long a, unsigned long b) {
   return __rv_rstsa16(a, b);
+}
+
+// CHECK-RV64-LABEL: @rstsa32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.rstsa32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long rstsa32(unsigned long a, unsigned long b) {
+  return __rv_rstsa32(a, b);
 }
 
 // CHECK-RV64-LABEL: @rsub8(
@@ -959,6 +1184,15 @@ unsigned long rsub8(unsigned long a, unsigned long b) {
 //
 unsigned long rsub16(unsigned long a, unsigned long b) {
   return __rv_rsub16(a, b);
+}
+
+// CHECK-RV64-LABEL: @rsub32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.rsub32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long rsub32(unsigned long a, unsigned long b) {
+  return __rv_rsub32(a, b);
 }
 
 // CHECK-RV64-LABEL: @rsubw(
@@ -1045,6 +1279,15 @@ unsigned long sll8(unsigned long a, unsigned int b) {
   return __rv_sll8(a, b);
 }
 
+// CHECK-RV64-LABEL: @slli8(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.sll8.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long slli8(unsigned long a, unsigned int b) {
+  return __rv_sll8(a, 1);
+}
+
 // CHECK-RV64-LABEL: @sll16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[CONV:%.*]] = zext i32 [[B:%.*]] to i64
@@ -1053,6 +1296,15 @@ unsigned long sll8(unsigned long a, unsigned int b) {
 //
 unsigned long sll16(unsigned long a, unsigned int b) {
   return __rv_sll16(a, b);
+}
+
+// CHECK-RV64-LABEL: @slli16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.sll16.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long slli16(unsigned long a, unsigned int b) {
+  return __rv_sll16(a, 1);
 }
 
 // CHECK-RV64-LABEL: @smaqa(
@@ -1100,6 +1352,15 @@ long smbb16(unsigned long a, unsigned long b) {
   return __rv_smbb16(a, b);
 }
 
+// CHECK-RV64-LABEL: @smbb32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.smbb32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long smbb32(long a, long b) {
+  return __rv_smbb32(a, b);
+}
+
 // CHECK-RV64-LABEL: @smbt16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.smbt16.i64.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -1109,6 +1370,15 @@ long smbt16(unsigned long a, unsigned long b) {
   return __rv_smbt16(a, b);
 }
 
+// CHECK-RV64-LABEL: @smbt32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.smbt32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long smbt32(long a, long b) {
+  return __rv_smbt32(a, b);
+}
+
 // CHECK-RV64-LABEL: @smtt16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.smtt16.i64.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -1116,6 +1386,15 @@ long smbt16(unsigned long a, unsigned long b) {
 //
 long smtt16(unsigned long a, unsigned long b) {
   return __rv_smtt16(a, b);
+}
+
+// CHECK-RV64-LABEL: @smtt32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.smtt32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+long smtt32(long a, long b) {
+  return __rv_smtt32(a, b);
 }
 
 // CHECK-RV64-LABEL: @smds(
@@ -1237,6 +1516,15 @@ unsigned long sra8(unsigned long a, unsigned int b) {
   return __rv_sra8(a, b);
 }
 
+// CHECK-RV64-LABEL: @srai8(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.sra8.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long srai8(unsigned long a, unsigned int b) {
+  return __rv_sra8(a, 1);
+}
+
 // CHECK-RV64-LABEL: @sra8_u(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[CONV:%.*]] = zext i32 [[B:%.*]] to i64
@@ -1245,6 +1533,15 @@ unsigned long sra8(unsigned long a, unsigned int b) {
 //
 unsigned long sra8_u(unsigned long a, unsigned int b) {
   return __rv_sra8_u(a, b);
+}
+
+// CHECK-RV64-LABEL: @srai8_u(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.sra8.u.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long srai8_u(unsigned long a, unsigned int b) {
+  return __rv_sra8_u(a, 1);
 }
 
 // CHECK-RV64-LABEL: @sra16(
@@ -1257,6 +1554,15 @@ unsigned long sra16(unsigned long a, unsigned int b) {
   return __rv_sra16(a, b);
 }
 
+// CHECK-RV64-LABEL: @srai16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.sra16.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long srai16(unsigned long a, unsigned int b) {
+  return __rv_sra16(a, 1);
+}
+
 // CHECK-RV64-LABEL: @sra16_u(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[CONV:%.*]] = zext i32 [[B:%.*]] to i64
@@ -1265,6 +1571,15 @@ unsigned long sra16(unsigned long a, unsigned int b) {
 //
 unsigned long sra16_u(unsigned long a, unsigned int b) {
   return __rv_sra16_u(a, b);
+}
+
+// CHECK-RV64-LABEL: @srai16_u(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.sra16.u.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long srai16_u(unsigned long a, unsigned int b) {
+  return __rv_sra16_u(a, 1);
 }
 
 // CHECK-RV64-LABEL: @srl8(
@@ -1277,6 +1592,15 @@ unsigned long srl8(unsigned long a, unsigned int b) {
   return __rv_srl8(a, b);
 }
 
+// CHECK-RV64-LABEL: @srli8(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.srl8.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long srli8(unsigned long a, unsigned int b) {
+  return __rv_srl8(a, 1);
+}
+
 // CHECK-RV64-LABEL: @srl8_u(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[CONV:%.*]] = zext i32 [[B:%.*]] to i64
@@ -1285,6 +1609,15 @@ unsigned long srl8(unsigned long a, unsigned int b) {
 //
 unsigned long srl8_u(unsigned long a, unsigned int b) {
   return __rv_srl8_u(a, b);
+}
+
+// CHECK-RV64-LABEL: @srli8_u(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.srl8.u.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long srli8_u(unsigned long a, unsigned int b) {
+  return __rv_srl8_u(a, 1);
 }
 
 // CHECK-RV64-LABEL: @srl16(
@@ -1297,6 +1630,15 @@ unsigned long srl16(unsigned long a, unsigned int b) {
   return __rv_srl16(a, b);
 }
 
+// CHECK-RV64-LABEL: @srli16(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.srl16.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long srli16(unsigned long a, unsigned int b) {
+  return __rv_srl16(a, 1);
+}
+
 // CHECK-RV64-LABEL: @srl16_u(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[CONV:%.*]] = zext i32 [[B:%.*]] to i64
@@ -1305,6 +1647,15 @@ unsigned long srl16(unsigned long a, unsigned int b) {
 //
 unsigned long srl16_u(unsigned long a, unsigned int b) {
   return __rv_srl16_u(a, b);
+}
+
+// CHECK-RV64-LABEL: @srli16_u(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.srl16.u.i64.i64(i64 [[A:%.*]], i64 1)
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long srli16_u(unsigned long a, unsigned int b) {
+  return __rv_srl16_u(a, 1);
 }
 
 // CHECK-RV64-LABEL: @stas16(
@@ -1316,6 +1667,15 @@ unsigned long stas16(unsigned long a, unsigned long b) {
   return __rv_stas16(a, b);
 }
 
+// CHECK-RV64-LABEL: @stas32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.stas32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long stas32(unsigned long a, unsigned long b) {
+  return __rv_stas32(a, b);
+}
+
 // CHECK-RV64-LABEL: @stsa16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.stsa16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -1323,6 +1683,15 @@ unsigned long stas16(unsigned long a, unsigned long b) {
 //
 unsigned long stsa16(unsigned long a, unsigned long b) {
   return __rv_stsa16(a, b);
+}
+
+// CHECK-RV64-LABEL: @stsa32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.stsa32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long stsa32(unsigned long a, unsigned long b) {
+  return __rv_stsa32(a, b);
 }
 
 // CHECK-RV64-LABEL: @sub8(
@@ -1341,6 +1710,15 @@ unsigned long sub8(unsigned long a, unsigned long b) {
 //
 unsigned long sub16(unsigned long a, unsigned long b) {
   return __rv_sub16(a, b);
+}
+
+// CHECK-RV64-LABEL: @sub32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.sub32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long sub32(unsigned long a, unsigned long b) {
+  return __rv_sub32(a, b);
 }
 
 // CHECK-RV64-LABEL: @sunpkd810(
@@ -1487,6 +1865,15 @@ unsigned long ukadd16(unsigned long a, unsigned long b) {
   return __rv_ukadd16(a, b);
 }
 
+// CHECK-RV64-LABEL: @ukadd32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ukadd32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long ukadd32(unsigned long a, unsigned long b) {
+  return __rv_ukadd32(a, b);
+}
+
 // CHECK-RV64-LABEL: @ukaddh(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[CONV:%.*]] = sext i32 [[A:%.*]] to i64
@@ -1518,6 +1905,15 @@ unsigned long ukcras16(unsigned long a, unsigned long b) {
   return __rv_ukcras16(a, b);
 }
 
+// CHECK-RV64-LABEL: @ukcras32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ukcras32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long ukcras32(unsigned long a, unsigned long b) {
+  return __rv_ukcras32(a, b);
+}
+
 // CHECK-RV64-LABEL: @ukcrsa16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ukcrsa16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -1525,6 +1921,15 @@ unsigned long ukcras16(unsigned long a, unsigned long b) {
 //
 unsigned long ukcrsa16(unsigned long a, unsigned long b) {
   return __rv_ukcrsa16(a, b);
+}
+
+// CHECK-RV64-LABEL: @ukcrsa32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ukcrsa32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long ukcrsa32(unsigned long a, unsigned long b) {
+  return __rv_ukcrsa32(a, b);
 }
 
 // CHECK-RV64-LABEL: @ukstas16(
@@ -1536,6 +1941,15 @@ unsigned long ukstas16(unsigned long a, unsigned long b) {
   return __rv_ukstas16(a, b);
 }
 
+// CHECK-RV64-LABEL: @ukstas32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ukstas32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long ukstas32(unsigned long a, unsigned long b) {
+  return __rv_ukstas32(a, b);
+}
+
 // CHECK-RV64-LABEL: @ukstsa16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ukstsa16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -1543,6 +1957,15 @@ unsigned long ukstas16(unsigned long a, unsigned long b) {
 //
 unsigned long ukstsa16(unsigned long a, unsigned long b) {
   return __rv_ukstsa16(a, b);
+}
+
+// CHECK-RV64-LABEL: @ukstsa32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ukstsa32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long ukstsa32(unsigned long a, unsigned long b) {
+  return __rv_ukstsa32(a, b);
 }
 
 // CHECK-RV64-LABEL: @uksub8(
@@ -1561,6 +1984,15 @@ unsigned long uksub8(unsigned long a, unsigned long b) {
 //
 unsigned long uksub16(unsigned long a, unsigned long b) {
   return __rv_uksub16(a, b);
+}
+
+// CHECK-RV64-LABEL: @uksub32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.uksub32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long uksub32(unsigned long a, unsigned long b) {
+  return __rv_uksub32(a, b);
 }
 
 // CHECK-RV64-LABEL: @uksubh(
@@ -1641,11 +2073,20 @@ unsigned long uradd8(unsigned long a, unsigned long b) {
 
 // CHECK-RV64-LABEL: @uradd16(
 // CHECK-RV64-NEXT:  entry:
-// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.uradd8.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.uradd16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
 // CHECK-RV64-NEXT:    ret i64 [[TMP0]]
 //
 unsigned long uradd16(unsigned long a, unsigned long b) {
-  return __rv_uradd8(a, b);
+  return __rv_uradd16(a, b);
+}
+
+// CHECK-RV64-LABEL: @uradd32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.uradd32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long uradd32(unsigned long a, unsigned long b) {
+  return __rv_uradd32(a, b);
 }
 
 // CHECK-RV64-LABEL: @uraddw(
@@ -1668,6 +2109,15 @@ unsigned long urcras16(unsigned long a, unsigned long b) {
   return __rv_urcras16(a, b);
 }
 
+// CHECK-RV64-LABEL: @urcras32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.urcras32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long urcras32(unsigned long a, unsigned long b) {
+  return __rv_urcras32(a, b);
+}
+
 // CHECK-RV64-LABEL: @urcrsa16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.urcrsa16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -1675,6 +2125,15 @@ unsigned long urcras16(unsigned long a, unsigned long b) {
 //
 unsigned long urcrsa16(unsigned long a, unsigned long b) {
   return __rv_urcrsa16(a, b);
+}
+
+// CHECK-RV64-LABEL: @urcrsa32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.urcrsa32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long urcrsa32(unsigned long a, unsigned long b) {
+  return __rv_urcrsa32(a, b);
 }
 
 // CHECK-RV64-LABEL: @urstas16(
@@ -1686,6 +2145,15 @@ unsigned long urstas16(unsigned long a, unsigned long b) {
   return __rv_urstas16(a, b);
 }
 
+// CHECK-RV64-LABEL: @urstas32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.urstas32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long urstas32(unsigned long a, unsigned long b) {
+  return __rv_urstas32(a, b);
+}
+
 // CHECK-RV64-LABEL: @urstsa16(
 // CHECK-RV64-NEXT:  entry:
 // CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.urstsa16.i64(i64 [[A:%.*]], i64 [[B:%.*]])
@@ -1693,6 +2161,15 @@ unsigned long urstas16(unsigned long a, unsigned long b) {
 //
 unsigned long urstsa16(unsigned long a, unsigned long b) {
   return __rv_urstsa16(a, b);
+}
+
+// CHECK-RV64-LABEL: @urstsa32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.urstsa32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long urstsa32(unsigned long a, unsigned long b) {
+  return __rv_urstsa32(a, b);
 }
 
 // CHECK-RV64-LABEL: @ursub8(
@@ -1711,6 +2188,15 @@ unsigned long ursub8(unsigned long a, unsigned long b) {
 //
 unsigned long ursub16(unsigned long a, unsigned long b) {
   return __rv_ursub16(a, b);
+}
+
+// CHECK-RV64-LABEL: @ursub32(
+// CHECK-RV64-NEXT:  entry:
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = tail call i64 @llvm.riscv.ursub32.i64(i64 [[A:%.*]], i64 [[B:%.*]])
+// CHECK-RV64-NEXT:    ret i64 [[TMP0]]
+//
+unsigned long ursub32(unsigned long a, unsigned long b) {
+  return __rv_ursub32(a, b);
 }
 
 // CHECK-RV64-LABEL: @ursubw(

--- a/llvm/include/llvm/IR/IntrinsicsRISCV.td
+++ b/llvm/include/llvm/IR/IntrinsicsRISCV.td
@@ -182,6 +182,36 @@ let TargetPrefix = "riscv" in {
 
   defm add8     : RVPBinaryIntrinsics;
   defm add16    : RVPBinaryIntrinsics;
+  defm add32    : RVPBinaryIntrinsics;
+  defm radd32   : RVPBinaryIntrinsics;
+  defm uradd32  : RVPBinaryIntrinsics;
+  defm kadd32   : RVPBinaryIntrinsics;
+  defm ukadd32  : RVPBinaryIntrinsics;
+  defm sub32    : RVPBinaryIntrinsics;
+  defm rsub32   : RVPBinaryIntrinsics;
+  defm ursub32  : RVPBinaryIntrinsics;
+  defm ksub32   : RVPBinaryIntrinsics;
+  defm uksub32  : RVPBinaryIntrinsics;
+  defm cras32   : RVPBinaryIntrinsics;
+  defm rcras32  : RVPBinaryIntrinsics;
+  defm urcras32 : RVPBinaryIntrinsics;
+  defm kcras32  : RVPBinaryIntrinsics;
+  defm ukcras32 : RVPBinaryIntrinsics;
+  defm crsa32   : RVPBinaryIntrinsics;
+  defm rcrsa32  : RVPBinaryIntrinsics;
+  defm urcrsa32 : RVPBinaryIntrinsics;
+  defm kcrsa32  : RVPBinaryIntrinsics;
+  defm ukcrsa32 : RVPBinaryIntrinsics;
+  defm stas32   : RVPBinaryIntrinsics;
+  defm rstas32  : RVPBinaryIntrinsics;
+  defm urstas32 : RVPBinaryIntrinsics;
+  defm kstas32  : RVPBinaryIntrinsics;
+  defm ukstas32 : RVPBinaryIntrinsics;
+  defm stsa32   : RVPBinaryIntrinsics;
+  defm rstsa32  : RVPBinaryIntrinsics;
+  defm urstsa32 : RVPBinaryIntrinsics;
+  defm kstsa32  : RVPBinaryIntrinsics;
+  defm ukstsa32 : RVPBinaryIntrinsics;
   defm ave      : RVPBinaryIntrinsics;
   defm bitrev   : RVPBinaryIntrinsics;
   defm cmpeq8   : RVPBinaryIntrinsics;
@@ -198,6 +228,8 @@ let TargetPrefix = "riscv" in {
   defm khmx8    : RVPBinaryIntrinsics;
   defm khm16    : RVPBinaryIntrinsics;
   defm khmx16   : RVPBinaryIntrinsics;
+  defm kmda32   : RVPBinaryIntrinsics;
+  defm kmxda32  : RVPBinaryIntrinsics;
   defm ksllw    : RVPBinaryIntrinsics;
   defm kslraw   : RVPBinaryIntrinsics;
   defm kslraw_u : RVPBinaryIntrinsics;
@@ -231,10 +263,16 @@ let TargetPrefix = "riscv" in {
   defm scmplt16 : RVPBinaryIntrinsics;
   defm smax8    : RVPBinaryIntrinsics;
   defm smax16   : RVPBinaryIntrinsics;
+  defm smbb32   : RVPBinaryIntrinsics;
+  defm smbt32   : RVPBinaryIntrinsics;
+  defm smtt32   : RVPBinaryIntrinsics;
   defm smin8    : RVPBinaryIntrinsics;
   defm smin16   : RVPBinaryIntrinsics;
   defm smmul    : RVPBinaryIntrinsics;
   defm smmul_u  : RVPBinaryIntrinsics;
+  defm smds32   : RVPBinaryIntrinsics;
+  defm smdrs32  : RVPBinaryIntrinsics;
+  defm smxds32  : RVPBinaryIntrinsics;
   defm stas16   : RVPBinaryIntrinsics;
   defm stsa16   : RVPBinaryIntrinsics;
   defm sub8     : RVPBinaryIntrinsics;
@@ -279,21 +317,27 @@ let TargetPrefix = "riscv" in {
     def "int_riscv_" # NAME : RVPBinaryABBIntrinsics;
   }
 
-  defm kdmbb  : RVPBinaryABBIntrinsics;
-  defm kdmbt  : RVPBinaryABBIntrinsics;
-  defm kdmtt  : RVPBinaryABBIntrinsics;
-  defm khmbb  : RVPBinaryABBIntrinsics;
-  defm khmbt  : RVPBinaryABBIntrinsics;
-  defm khmtt  : RVPBinaryABBIntrinsics;
-  defm kmda   : RVPBinaryABBIntrinsics;
-  defm kmxda  : RVPBinaryABBIntrinsics;
-  defm pbsad  : RVPBinaryABBIntrinsics;
-  defm smbb16 : RVPBinaryABBIntrinsics;
-  defm smbt16 : RVPBinaryABBIntrinsics;
-  defm smtt16 : RVPBinaryABBIntrinsics;
-  defm smds   : RVPBinaryABBIntrinsics;
-  defm smdrs  : RVPBinaryABBIntrinsics;
-  defm smxds  : RVPBinaryABBIntrinsics;
+  defm kdmbb   : RVPBinaryABBIntrinsics;
+  defm kdmbt   : RVPBinaryABBIntrinsics;
+  defm kdmtt   : RVPBinaryABBIntrinsics;
+  defm khmbb   : RVPBinaryABBIntrinsics;
+  defm khmbt   : RVPBinaryABBIntrinsics;
+  defm khmtt   : RVPBinaryABBIntrinsics;
+  defm kmda    : RVPBinaryABBIntrinsics;
+  defm kmxda   : RVPBinaryABBIntrinsics;
+  defm pbsad   : RVPBinaryABBIntrinsics;
+  defm smbb16  : RVPBinaryABBIntrinsics;
+  defm smbt16  : RVPBinaryABBIntrinsics;
+  defm smtt16  : RVPBinaryABBIntrinsics;
+  defm smds    : RVPBinaryABBIntrinsics;
+  defm smdrs   : RVPBinaryABBIntrinsics;
+  defm smxds   : RVPBinaryABBIntrinsics;
+  defm khmbb16 : RVPBinaryABBIntrinsics;
+  defm khmbt16 : RVPBinaryABBIntrinsics;
+  defm khmtt16 : RVPBinaryABBIntrinsics;
+  defm kdmbb16 : RVPBinaryABBIntrinsics;
+  defm kdmbt16 : RVPBinaryABBIntrinsics;
+  defm kdmtt16 : RVPBinaryABBIntrinsics;
 
   class RVPBinaryAABIntrinsics
       : Intrinsic<[llvm_any_ty],
@@ -345,12 +389,19 @@ let TargetPrefix = "riscv" in {
     def "int_riscv_" # NAME : RVPTernaryIntrinsics;
   }
 
-  defm bpick   : RVPTernaryIntrinsics;
-  defm insb    : RVPTernaryIntrinsics;
-  defm kmmac   : RVPTernaryIntrinsics;
-  defm kmmac_u : RVPTernaryIntrinsics;
-  defm kmmsb   : RVPTernaryIntrinsics;
-  defm kmmsb_u : RVPTernaryIntrinsics;
+  defm bpick    : RVPTernaryIntrinsics;
+  defm insb     : RVPTernaryIntrinsics;
+  defm kmada32  : RVPTernaryIntrinsics;
+  defm kmaxda32 : RVPTernaryIntrinsics;
+  defm kmads32  : RVPTernaryIntrinsics;
+  defm kmadrs32 : RVPTernaryIntrinsics;
+  defm kmaxds32 : RVPTernaryIntrinsics;
+  defm kmsda32  : RVPTernaryIntrinsics;
+  defm kmsxda32 : RVPTernaryIntrinsics;
+  defm kmmac    : RVPTernaryIntrinsics;
+  defm kmmac_u  : RVPTernaryIntrinsics;
+  defm kmmsb    : RVPTernaryIntrinsics;
+  defm kmmsb_u  : RVPTernaryIntrinsics;
 
   class RVPTernaryAABBIntrinsics
       : Intrinsic<[llvm_any_ty],
@@ -378,6 +429,9 @@ let TargetPrefix = "riscv" in {
   defm smaqa    : RVPTernaryAABBIntrinsics;
   defm smaqa_su : RVPTernaryAABBIntrinsics;
   defm umaqa    : RVPTernaryAABBIntrinsics;
+  defm kdmabb16 : RVPTernaryAABBIntrinsics;
+  defm kdmabt16 : RVPTernaryAABBIntrinsics;
+  defm kdmatt16 : RVPTernaryAABBIntrinsics;
 
   class RVPTernaryAAABIntrinsics
       : Intrinsic<[llvm_any_ty],
@@ -860,7 +914,7 @@ let TargetPrefix = "riscv" in {
   class RISCVClassifyMasked
         : Intrinsic<[LLVMVectorOfBitcastsToInt<0>],
                     [LLVMVectorOfBitcastsToInt<0>, llvm_anyvector_ty,
-                     LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>, 
+                     LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                      llvm_anyint_ty, LLVMMatchType<1>],
                     [IntrNoMem, ImmArg<ArgIndex<4>>]>, RISCVVIntrinsic {
     let VLOperand = 3;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -113,7 +113,7 @@ class RVPShiftI4<bits<7> funct7, bits<1> funct1,
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
-class RVPShiftI5<bits<7> funct7, bits<3> funct3, string opcodestr, 
+class RVPShiftI5<bits<7> funct7, bits<3> funct3, string opcodestr,
                  DAGOperand rs1_kind = GPR>
     : RVInstI<funct3, OPC_OP_P, (outs GPR:$rd), (ins rs1_kind:$rs1, uimm5:$shamt),
               opcodestr, "$rd, $rs1, $shamt"> {
@@ -911,6 +911,11 @@ def : InstAlias<"clrov",    (CSRRCI      X0, SysRegVXSAT.Encoding,  1)>;
 def : InstAlias<"swap16 $rd, $rs1", (PKBT16 GPR:$rd, GPR:$rs1, GPR:$rs1)>;
 }
 
+let Predicates = [HasStdExtZpn, IsRV64] in {
+def : InstAlias<"smbb32 $rd, $rs1, $rs2",  (MULSR64_64 GPR:$rd, GPR:$rs1, GPR:$rs2)>;
+def : InstAlias<"kmada32 $rd, $rs1, $rs2", (KMAR64_64 GPR:$rd, GPR:$rs1, GPR:$rs2)>;
+}
+
 //===----------------------------------------------------------------------===//
 // Intrinsics codegen patterns
 //===----------------------------------------------------------------------===//
@@ -1104,6 +1109,53 @@ def : RVPBinaryIntPat<URSUB16,  "ursub16">;
 def : RVPBinaryIntPat<URSUBW,   "ursubw">;
 } // Predicates = [HasStdExtZpn]
 
+let Predicates = [HasStdExtZpn, IsRV64] in {
+def : RVPBinaryIntPat<ADD32,      "add32">;
+def : RVPBinaryIntPat<RADD32,     "radd32">;
+def : RVPBinaryIntPat<URADD32,    "uradd32">;
+def : RVPBinaryIntPat<KADD32,     "kadd32">;
+def : RVPBinaryIntPat<UKADD32,    "ukadd32">;
+def : RVPBinaryIntPat<SUB32,      "sub32">;
+def : RVPBinaryIntPat<RSUB32,     "rsub32">;
+def : RVPBinaryIntPat<URSUB32,    "ursub32">;
+def : RVPBinaryIntPat<KSUB32,     "ksub32">;
+def : RVPBinaryIntPat<UKSUB32,    "uksub32">;
+def : RVPBinaryIntPat<CRAS32,     "cras32">;
+def : RVPBinaryIntPat<RCRAS32,    "rcras32">;
+def : RVPBinaryIntPat<URCRAS32,   "urcras32">;
+def : RVPBinaryIntPat<KCRAS32,    "kcras32">;
+def : RVPBinaryIntPat<UKCRAS32,   "ukcras32">;
+def : RVPBinaryIntPat<CRSA32,     "crsa32">;
+def : RVPBinaryIntPat<RCRSA32,    "rcrsa32">;
+def : RVPBinaryIntPat<URCRSA32,   "urcrsa32">;
+def : RVPBinaryIntPat<KCRSA32,    "kcrsa32">;
+def : RVPBinaryIntPat<UKCRSA32,   "ukcrsa32">;
+def : RVPBinaryIntPat<STAS32,     "stas32">;
+def : RVPBinaryIntPat<RSTAS32,    "rstas32">;
+def : RVPBinaryIntPat<URSTAS32,   "urstas32">;
+def : RVPBinaryIntPat<KSTAS32,    "kstas32">;
+def : RVPBinaryIntPat<UKSTAS32,   "ukstas32">;
+def : RVPBinaryIntPat<STSA32,     "stsa32">;
+def : RVPBinaryIntPat<RSTSA32,    "rstsa32">;
+def : RVPBinaryIntPat<URSTSA32,   "urstsa32">;
+def : RVPBinaryIntPat<KSTSA32,    "kstsa32">;
+def : RVPBinaryIntPat<UKSTSA32,   "ukstsa32">;
+def : RVPBinaryIntPat<KHMBB16,    "khmbb16">;
+def : RVPBinaryIntPat<KHMBT16,    "khmbt16">;
+def : RVPBinaryIntPat<KHMTT16,    "khmtt16">;
+def : RVPBinaryIntPat<KDMBB16,    "kdmbb16">;
+def : RVPBinaryIntPat<KDMBT16,    "kdmbt16">;
+def : RVPBinaryIntPat<KDMTT16,    "kdmtt16">;
+def : RVPBinaryIntPat<KMDA32,     "kmda32">;
+def : RVPBinaryIntPat<KMXDA32,    "kmxda32">;
+def : RVPBinaryIntPat<MULSR64_64, "smbb32">;
+def : RVPBinaryIntPat<SMBT32,     "smbt32">;
+def : RVPBinaryIntPat<SMTT32,     "smtt32">;
+def : RVPBinaryIntPat<SMDS32,     "smds32">;
+def : RVPBinaryIntPat<SMDRS32,    "smdrs32">;
+def : RVPBinaryIntPat<SMXDS32,    "smxds32">;
+} // Predicates = [HasStdExtZpn, IsRV64]
+
 class RVPBinaryI3IntPat<RVInst Inst, string IntID>
     : Pat<(XLenVT (!cast<Intrinsic>("int_riscv_" # IntID)
                    XLenVT:$rs1, uimm3:$rs2)),
@@ -1113,6 +1165,11 @@ let Predicates = [HasStdExtZpn] in {
 def : RVPBinaryI3IntPat<SCLIP8, "sclip8">;
 def : RVPBinaryI3IntPat<UCLIP8, "uclip8">;
 def : RVPBinaryI3IntPat<KSLLI8, "ksll8">;
+def : RVPBinaryI3IntPat<SRAI8,  "sra8">;
+def : RVPBinaryI3IntPat<SRAI8U, "sra8_u">;
+def : RVPBinaryI3IntPat<SRLI8,  "srl8">;
+def : RVPBinaryI3IntPat<SRLI8U, "srl8_u">;
+def : RVPBinaryI3IntPat<SLLI8,  "sll8">;
 } // Predicates = [HasStdExtZpn]
 
 class RVPBinaryI4IntPat<RVInst Inst, string IntID>
@@ -1124,6 +1181,11 @@ let Predicates = [HasStdExtZpn] in {
 def : RVPBinaryI4IntPat<SCLIP16, "sclip16">;
 def : RVPBinaryI4IntPat<UCLIP16, "uclip16">;
 def : RVPBinaryI4IntPat<KSLLI16, "ksll16">;
+def : RVPBinaryI4IntPat<SRAI16,  "sra16">;
+def : RVPBinaryI4IntPat<SRAI16U, "sra16_u">;
+def : RVPBinaryI4IntPat<SRLI16,  "srl16">;
+def : RVPBinaryI4IntPat<SRLI16U, "srl16_u">;
+def : RVPBinaryI4IntPat<SLLI16,  "sll16">;
 } // Predicates = [HasStdExtZpn]
 
 class RVPBinaryI5IntPat<RVInst Inst, string IntID>
@@ -1144,37 +1206,50 @@ class RVPTernaryIntPat<RVInst Inst, string IntID>
           (Inst GPR:$rs1, GPR:$rs2, GPR:$rs3)>;
 
 let Predicates = [HasStdExtZpn] in {
-def : RVPTernaryIntPat<BPICK,    "bpick">;
-def : RVPTernaryIntPat<KDMABB,   "kdmabb">;
-def : RVPTernaryIntPat<KDMABT,   "kdmabt">;
-def : RVPTernaryIntPat<KDMATT,   "kdmatt">;
-def : RVPTernaryIntPat<KMABB,    "kmabb">;
-def : RVPTernaryIntPat<KMABT,    "kmabt">;
-def : RVPTernaryIntPat<KMATT,    "kmatt">;
-def : RVPTernaryIntPat<KMADA,    "kmada">;
-def : RVPTernaryIntPat<KMAXDA,   "kmaxda">;
-def : RVPTernaryIntPat<KMADS,    "kmads">;
-def : RVPTernaryIntPat<KMADRS,   "kmadrs">;
-def : RVPTernaryIntPat<KMAXDS,   "kmaxds">;
-def : RVPTernaryIntPat<KMMAC,    "kmmac">;
-def : RVPTernaryIntPat<KMMACU,   "kmmac_u">;
-def : RVPTernaryIntPat<KMMAWB,   "kmmawb">;
-def : RVPTernaryIntPat<KMMAWBU,  "kmmawb_u">;
-def : RVPTernaryIntPat<KMMAWB2,  "kmmawb2">;
-def : RVPTernaryIntPat<KMMAWB2U, "kmmawb2_u">;
-def : RVPTernaryIntPat<KMMAWT,   "kmmawt">;
-def : RVPTernaryIntPat<KMMAWTU,  "kmmawt_u">;
-def : RVPTernaryIntPat<KMMAWT2,  "kmmawt2">;
-def : RVPTernaryIntPat<KMMAWT2U, "kmmawt2_u">;
-def : RVPTernaryIntPat<KMMSB,    "kmmsb">;
-def : RVPTernaryIntPat<KMMSBU,   "kmmsb_u">;
-def : RVPTernaryIntPat<KMSDA,    "kmsda">;
-def : RVPTernaryIntPat<KMSXDA,   "kmsxda">;
-def : RVPTernaryIntPat<PBSADA,   "pbsada">;
-def : RVPTernaryIntPat<SMAQA,    "smaqa">;
-def : RVPTernaryIntPat<SMAQASU,  "smaqa_su">;
-def : RVPTernaryIntPat<UMAQA,    "umaqa">;
+def : RVPTernaryIntPat<BPICK,     "bpick">;
+def : RVPTernaryIntPat<KDMABB,    "kdmabb">;
+def : RVPTernaryIntPat<KDMABT,    "kdmabt">;
+def : RVPTernaryIntPat<KDMATT,    "kdmatt">;
+def : RVPTernaryIntPat<KMABB,     "kmabb">;
+def : RVPTernaryIntPat<KMABT,     "kmabt">;
+def : RVPTernaryIntPat<KMATT,     "kmatt">;
+def : RVPTernaryIntPat<KMADA,     "kmada">;
+def : RVPTernaryIntPat<KMAXDA,    "kmaxda">;
+def : RVPTernaryIntPat<KMADS,     "kmads">;
+def : RVPTernaryIntPat<KMADRS,    "kmadrs">;
+def : RVPTernaryIntPat<KMAXDS,    "kmaxds">;
+def : RVPTernaryIntPat<KMAR64_64, "kmada32">;
+def : RVPTernaryIntPat<KMAXDA32,  "kmaxda32">;
+def : RVPTernaryIntPat<KMADS32,   "kmads32">;
+def : RVPTernaryIntPat<KMADRS32,  "kmadrs32">;
+def : RVPTernaryIntPat<KMAXDS,    "kmaxds32">;
+def : RVPTernaryIntPat<KMSDA,     "kmsda32">;
+def : RVPTernaryIntPat<KMSXDA,    "kmsxda32">;
+def : RVPTernaryIntPat<KMMAC,     "kmmac">;
+def : RVPTernaryIntPat<KMMACU,    "kmmac_u">;
+def : RVPTernaryIntPat<KMMAWB,    "kmmawb">;
+def : RVPTernaryIntPat<KMMAWBU,   "kmmawb_u">;
+def : RVPTernaryIntPat<KMMAWB2,   "kmmawb2">;
+def : RVPTernaryIntPat<KMMAWB2U,  "kmmawb2_u">;
+def : RVPTernaryIntPat<KMMAWT,    "kmmawt">;
+def : RVPTernaryIntPat<KMMAWTU,   "kmmawt_u">;
+def : RVPTernaryIntPat<KMMAWT2,   "kmmawt2">;
+def : RVPTernaryIntPat<KMMAWT2U,  "kmmawt2_u">;
+def : RVPTernaryIntPat<KMMSB,     "kmmsb">;
+def : RVPTernaryIntPat<KMMSBU,    "kmmsb_u">;
+def : RVPTernaryIntPat<KMSDA,     "kmsda">;
+def : RVPTernaryIntPat<KMSXDA,    "kmsxda">;
+def : RVPTernaryIntPat<PBSADA,    "pbsada">;
+def : RVPTernaryIntPat<SMAQA,     "smaqa">;
+def : RVPTernaryIntPat<SMAQASU,   "smaqa_su">;
+def : RVPTernaryIntPat<UMAQA,     "umaqa">;
 } // Predicates = [HasStdExtZpn]
+
+let Predicates = [HasStdExtZpn, IsRV64] in {
+def : RVPTernaryIntPat<KDMABB16, "kdmabb16">;
+def : RVPTernaryIntPat<KDMABT16, "kdmabt16">;
+def : RVPTernaryIntPat<KDMATT16, "kdmatt16">;
+}
 
 class RVPTernaryINSBIntPat<RVInst Inst, string IntID>
     : Pat<(XLenVT (!cast<Intrinsic>("int_riscv_" # IntID)

--- a/llvm/test/CodeGen/RISCV/rv32zpn-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv32zpn-intrinsic.ll
@@ -1336,6 +1336,16 @@ entry:
   ret i32 %0
 }
 
+define i32 @slli8(i32 %a, i32 %b) {
+; CHECK-LABEL: slli8:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    slli8 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i32 @llvm.riscv.sll8.i32.i32(i32 %a, i32 1)
+  ret i32 %0
+}
+
 declare i32 @llvm.riscv.sll8.i32.i32(i32, i32)
 
 define i32 @sll16(i32 %a, i32 %b) {
@@ -1345,6 +1355,16 @@ define i32 @sll16(i32 %a, i32 %b) {
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i32 @llvm.riscv.sll16.i32.i32(i32 %a, i32 %b)
+  ret i32 %0
+}
+
+define i32 @slli16(i32 %a, i32 %b) {
+; CHECK-LABEL: slli16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    slli16 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i32 @llvm.riscv.sll16.i32.i32(i32 %a, i32 1)
   ret i32 %0
 }
 
@@ -1588,6 +1608,16 @@ entry:
   ret i32 %0
 }
 
+define i32 @srai8(i32 %a, i32 %b) {
+; CHECK-LABEL: srai8:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai8 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i32 @llvm.riscv.sra8.i32.i32(i32 %a, i32 1)
+  ret i32 %0
+}
+
 declare i32 @llvm.riscv.sra8.i32.i32(i32, i32)
 
 define i32 @sra8_u(i32 %a, i32 %b) {
@@ -1597,6 +1627,16 @@ define i32 @sra8_u(i32 %a, i32 %b) {
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i32 @llvm.riscv.sra8.u.i32.i32(i32 %a, i32 %b)
+  ret i32 %0
+}
+
+define i32 @srai8_u(i32 %a, i32 %b) {
+; CHECK-LABEL: srai8_u:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai8.u a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i32 @llvm.riscv.sra8.u.i32.i32(i32 %a, i32 1)
   ret i32 %0
 }
 
@@ -1612,6 +1652,16 @@ entry:
   ret i32 %0
 }
 
+define i32 @srai16(i32 %a, i32 %b) {
+; CHECK-LABEL: srai16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai16 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i32 @llvm.riscv.sra16.i32.i32(i32 %a, i32 1)
+  ret i32 %0
+}
+
 declare i32 @llvm.riscv.sra16.i32.i32(i32, i32)
 
 define i32 @sra16_u(i32 %a, i32 %b) {
@@ -1621,6 +1671,16 @@ define i32 @sra16_u(i32 %a, i32 %b) {
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i32 @llvm.riscv.sra16.u.i32.i32(i32 %a, i32 %b)
+  ret i32 %0
+}
+
+define i32 @srai16_u(i32 %a, i32 %b) {
+; CHECK-LABEL: srai16_u:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai16.u a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i32 @llvm.riscv.sra16.u.i32.i32(i32 %a, i32 1)
   ret i32 %0
 }
 
@@ -1636,6 +1696,16 @@ entry:
   ret i32 %0
 }
 
+define i32 @srli8(i32 %a, i32 %b) {
+; CHECK-LABEL: srli8:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srli8 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i32 @llvm.riscv.srl8.i32.i32(i32 %a, i32 1)
+  ret i32 %0
+}
+
 declare i32 @llvm.riscv.srl8.i32.i32(i32, i32)
 
 define i32 @srl8_u(i32 %a, i32 %b) {
@@ -1645,6 +1715,16 @@ define i32 @srl8_u(i32 %a, i32 %b) {
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i32 @llvm.riscv.srl8.u.i32.i32(i32 %a, i32 %b)
+  ret i32 %0
+}
+
+define i32 @srli8_u(i32 %a, i32 %b) {
+; CHECK-LABEL: srli8_u:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srli8.u a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i32 @llvm.riscv.srl8.u.i32.i32(i32 %a, i32 1)
   ret i32 %0
 }
 
@@ -1660,6 +1740,16 @@ entry:
   ret i32 %0
 }
 
+define i32 @srli16(i32 %a, i32 %b) {
+; CHECK-LABEL: srli16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srli16 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i32 @llvm.riscv.srl16.i32.i32(i32 %a, i32 1)
+  ret i32 %0
+}
+
 declare i32 @llvm.riscv.srl16.i32.i32(i32, i32)
 
 define i32 @srl16_u(i32 %a, i32 %b) {
@@ -1669,6 +1759,16 @@ define i32 @srl16_u(i32 %a, i32 %b) {
 ; CHECK-NEXT:    ret
 entry:
   %0 = tail call i32 @llvm.riscv.srl16.u.i32.i32(i32 %a, i32 %b)
+  ret i32 %0
+}
+
+define i32 @srli16_u(i32 %a, i32 %b) {
+; CHECK-LABEL: srli16_u:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srli16.u a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i32 @llvm.riscv.srl16.u.i32.i32(i32 %a, i32 1)
   ret i32 %0
 }
 

--- a/llvm/test/CodeGen/RISCV/rv64zpn-intrinsic.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zpn-intrinsic.ll
@@ -26,6 +26,18 @@ entry:
 
 declare i64 @llvm.riscv.add16.i64(i64, i64)
 
+define i64 @add32(i64 %a, i64 %b) {
+; CHECK-LABEL: add32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    add32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.add32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.add32.i64(i64, i64)
+
 define i64 @ave(i64 %a, i64 %b) {
 ; CHECK-LABEL: ave:
 ; CHECK:       # %bb.0: # %entry
@@ -170,6 +182,18 @@ entry:
 
 declare i64 @llvm.riscv.cras16.i64(i64, i64)
 
+define i64 @cras32(i64 %a, i64 %b) {
+; CHECK-LABEL: cras32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    cras32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.cras32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.cras32.i64(i64, i64)
+
 define i64 @crsa16(i64 %a, i64 %b) {
 ; CHECK-LABEL: crsa16:
 ; CHECK:       # %bb.0: # %entry
@@ -181,6 +205,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.crsa16.i64(i64, i64)
+
+define i64 @crsa32(i64 %a, i64 %b) {
+; CHECK-LABEL: crsa32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    crsa32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.crsa32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.crsa32.i64(i64, i64)
 
 define i64 @insb(i64 %a, i64 %b) {
 ; CHECK-LABEL: insb:
@@ -254,6 +290,18 @@ entry:
 
 declare i64 @llvm.riscv.kadd16.i64(i64, i64)
 
+define i64 @kadd32(i64 %a, i64 %b) {
+; CHECK-LABEL: kadd32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kadd32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kadd32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kadd32.i64(i64, i64)
+
 define i64 @kaddh(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: kaddh:
 ; CHECK:       # %bb.0: # %entry
@@ -294,6 +342,18 @@ entry:
 
 declare i64 @llvm.riscv.kcras16.i64(i64, i64)
 
+define i64 @kcras32(i64 %a, i64 %b) {
+; CHECK-LABEL: kcras32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kcras32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kcras32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kcras32.i64(i64, i64)
+
 define i64 @kcrsa16(i64 %a, i64 %b) {
 ; CHECK-LABEL: kcrsa16:
 ; CHECK:       # %bb.0: # %entry
@@ -305,6 +365,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.kcrsa16.i64(i64, i64)
+
+define i64 @kcrsa32(i64 %a, i64 %b) {
+; CHECK-LABEL: kcrsa32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kcrsa32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kcrsa32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kcrsa32.i64(i64, i64)
 
 define i64 @kdmbb(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: kdmbb:
@@ -324,6 +396,18 @@ entry:
 
 declare i64 @llvm.riscv.kdmbb.i64.i64(i64, i64)
 
+define i64 @kdmbb16(i64 %a, i64 %b) {
+; CHECK-LABEL: kdmbb16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kdmbb16 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kdmbb16.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kdmbb16.i64.i64(i64, i64)
+
 define i64 @kdmbt(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: kdmbt:
 ; CHECK:       # %bb.0: # %entry
@@ -341,6 +425,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.kdmbt.i64.i64(i64, i64)
+
+define i64 @kdmbt16(i64 %a, i64 %b) {
+; CHECK-LABEL: kdmbt16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kdmbt16 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kdmbt16.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kdmbt16.i64.i64(i64, i64)
 
 define i64 @kdmtt(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: kdmtt:
@@ -360,6 +456,18 @@ entry:
 
 declare i64 @llvm.riscv.kdmtt.i64.i64(i64, i64)
 
+define i64 @kdmtt16(i64 %a, i64 %b) {
+; CHECK-LABEL: kdmtt16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kdmtt16 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kdmtt16.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kdmtt16.i64.i64(i64, i64)
+
 define i64 @kdmabb(i64 %t, i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: kdmabb:
 ; CHECK:       # %bb.0: # %entry
@@ -377,6 +485,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.kdmabb.i64.i64(i64, i64, i64)
+
+define i64 @kdmabb16(i64 %t, i64 %a, i64 %b) {
+; CHECK-LABEL: kdmabb16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kdmabb16 a0, a1, a2
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kdmabb16.i64.i64(i64 %t, i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kdmabb16.i64.i64(i64, i64, i64)
 
 define i64 @kdmabt(i64 %t, i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: kdmabt:
@@ -396,6 +516,18 @@ entry:
 
 declare i64 @llvm.riscv.kdmabt.i64.i64(i64, i64, i64)
 
+define i64 @kdmabt16(i64 %t, i64 %a, i64 %b) {
+; CHECK-LABEL: kdmabt16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kdmabt16 a0, a1, a2
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kdmabt16.i64.i64(i64 %t, i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kdmabt16.i64.i64(i64, i64, i64)
+
 define i64 @kdmatt(i64 %t, i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: kdmatt:
 ; CHECK:       # %bb.0: # %entry
@@ -413,6 +545,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.kdmatt.i64.i64(i64, i64, i64)
+
+define i64 @kdmatt16(i64 %t, i64 %a, i64 %b) {
+; CHECK-LABEL: kdmatt16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kdmatt16 a0, a1, a2
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kdmatt16.i64.i64(i64 %t, i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kdmatt16.i64.i64(i64, i64, i64)
 
 define i64 @khm8(i64 %a, i64 %b) {
 ; CHECK-LABEL: khm8:
@@ -480,6 +624,18 @@ entry:
 
 declare i64 @llvm.riscv.khmbb.i64.i64(i64, i64)
 
+define i64 @khmbb16(i64 %a, i64 %b) {
+; CHECK-LABEL: khmbb16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    khmbb16 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.khmbb16.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.khmbb16.i64.i64(i64, i64)
+
 define i64 @khmbt(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: khmbt:
 ; CHECK:       # %bb.0: # %entry
@@ -498,6 +654,18 @@ entry:
 
 declare i64 @llvm.riscv.khmbt.i64.i64(i64, i64)
 
+define i64 @khmbt16(i64 %a, i64 %b) {
+; CHECK-LABEL: khmbt16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    khmbt16 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.khmbt16.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.khmbt16.i64.i64(i64, i64)
+
 define i64 @khmtt(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: khmtt:
 ; CHECK:       # %bb.0: # %entry
@@ -515,6 +683,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.khmtt.i64.i64(i64, i64)
+
+define i64 @khmtt16(i64 %a, i64 %b) {
+; CHECK-LABEL: khmtt16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    khmtt16 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.khmtt16.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.khmtt16.i64.i64(i64, i64)
 
 define i64 @kmabb(i64 %t, i64 %a, i64 %b) {
 ; CHECK-LABEL: kmabb:
@@ -564,6 +744,18 @@ entry:
 
 declare i64 @llvm.riscv.kmada.i64.i64(i64, i64, i64)
 
+define i64 @kmada32(i64 %t, i64 %a, i64 %b) {
+; CHECK-LABEL: kmada32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kmada32 a0, a1, a2
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kmada32.i64.i64(i64 %t, i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kmada32.i64.i64(i64, i64, i64)
+
 define i64 @kmaxda(i64 %t, i64 %a, i64 %b) {
 ; CHECK-LABEL: kmaxda:
 ; CHECK:       # %bb.0: # %entry
@@ -575,6 +767,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.kmaxda.i64.i64(i64, i64, i64)
+
+define i64 @kmaxda32(i64 %t, i64 %a, i64 %b) {
+; CHECK-LABEL: kmaxda32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kmaxda32 a0, a1, a2
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kmaxda32.i64.i64(i64 %t, i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kmaxda32.i64.i64(i64, i64, i64)
 
 define i64 @kmads(i64 %t, i64 %a, i64 %b) {
 ; CHECK-LABEL: kmads:
@@ -588,6 +792,18 @@ entry:
 
 declare i64 @llvm.riscv.kmads.i64.i64(i64, i64, i64)
 
+define i64 @kmads32(i64 %t, i64 %a, i64 %b) {
+; CHECK-LABEL: kmads32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kmads32 a0, a1, a2
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kmads32.i64.i64(i64 %t, i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kmads32.i64.i64(i64, i64, i64)
+
 define i64 @kmadrs(i64 %t, i64 %a, i64 %b) {
 ; CHECK-LABEL: kmadrs:
 ; CHECK:       # %bb.0: # %entry
@@ -599,6 +815,17 @@ entry:
 }
 
 declare i64 @llvm.riscv.kmadrs.i64.i64(i64, i64, i64)
+
+define i64 @mkadrs32(i64 %t, i64 %a, i64 %b) {
+; CHECK-LABEL: mkadrs32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    tail llvm.riscv.mkadrs32.i64.i64@plt
+entry:
+  %0 = tail call i64 @llvm.riscv.mkadrs32.i64.i64(i64 %t, i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.mkadrs32.i64.i64(i64, i64, i64)
 
 define i64 @kmaxds(i64 %t, i64 %a, i64 %b) {
 ; CHECK-LABEL: kmaxds:
@@ -612,6 +839,18 @@ entry:
 
 declare i64 @llvm.riscv.kmaxds.i64.i64(i64, i64, i64)
 
+define i64 @kmaxds32(i64 %t, i64 %a, i64 %b) {
+; CHECK-LABEL: kmaxds32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kmaxds a0, a1, a2
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kmaxds32.i64.i64(i64 %t, i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kmaxds32.i64.i64(i64, i64, i64)
+
 define i64 @kmda(i64 %a, i64 %b) {
 ; CHECK-LABEL: kmda:
 ; CHECK:       # %bb.0: # %entry
@@ -624,6 +863,18 @@ entry:
 
 declare i64 @llvm.riscv.kmda.i64.i64(i64, i64)
 
+define i64 @kmda32(i64 %a, i64 %b) {
+; CHECK-LABEL: kmda32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kmda32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kmda32.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kmda32.i64.i64(i64, i64)
+
 define i64 @kmxda(i64 %a, i64 %b) {
 ; CHECK-LABEL: kmxda:
 ; CHECK:       # %bb.0: # %entry
@@ -635,6 +886,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.kmxda.i64.i64(i64, i64)
+
+define i64 @kmxda32(i64 %a, i64 %b) {
+; CHECK-LABEL: kmxda32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kmxda32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kmxda32.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kmxda32.i64.i64(i64, i64)
 
 define i64 @kmmac(i64 %t, i64 %a, i64 %b) {
 ; CHECK-LABEL: kmmac:
@@ -840,6 +1103,18 @@ entry:
 
 declare i64 @llvm.riscv.kmsda.i64.i64(i64, i64, i64)
 
+define i64 @kmsda32(i64 %t, i64 %a, i64 %b) {
+; CHECK-LABEL: kmsda32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kmsda a0, a1, a2
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kmsda32.i64.i64(i64 %t, i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kmsda32.i64.i64(i64, i64, i64)
+
 define i64 @kmsxda(i64 %t, i64 %a, i64 %b) {
 ; CHECK-LABEL: kmsxda:
 ; CHECK:       # %bb.0: # %entry
@@ -851,6 +1126,17 @@ entry:
 }
 
 declare i64 @llvm.riscv.kmsxda.i64.i64(i64, i64, i64)
+
+define i64 @mksxda32(i64 %t, i64 %a, i64 %b) {
+; CHECK-LABEL: mksxda32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    tail llvm.riscv.mksxda32.i64.i64@plt
+entry:
+  %0 = tail call i64 @llvm.riscv.mksxda32.i64.i64(i64 %t, i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.mksxda32.i64.i64(i64, i64, i64)
 
 define i64 @ksllw(i64 %a, i32 signext %b) {
 ; CHECK-LABEL: ksllw:
@@ -880,6 +1166,16 @@ entry:
   ret i64 %0
 }
 
+define i64 @kslli8(i64 %a, i32 signext %b) {
+; CHECK-LABEL: kslli8:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kslli8 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.ksll8.i64.i64(i64 %a, i64 1)
+  ret i64 %0
+}
+
 declare i64 @llvm.riscv.ksll8.i64.i64(i64, i64)
 
 define i64 @ksll16(i64 %a, i32 signext %b) {
@@ -892,6 +1188,16 @@ define i64 @ksll16(i64 %a, i32 signext %b) {
 entry:
   %conv = zext i32 %b to i64
   %0 = tail call i64 @llvm.riscv.ksll16.i64.i64(i64 %a, i64 %conv)
+  ret i64 %0
+}
+
+define i64 @kslli16(i64 %a, i32 signext %b) {
+; CHECK-LABEL: kslli16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kslli16 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.ksll16.i64.i64(i64 %a, i64 1)
   ret i64 %0
 }
 
@@ -989,6 +1295,18 @@ entry:
 
 declare i64 @llvm.riscv.kstas16.i64(i64, i64)
 
+define i64 @kstas32(i64 %a, i64 %b) {
+; CHECK-LABEL: kstas32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kstas32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kstas32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kstas32.i64(i64, i64)
+
 define i64 @kstsa16(i64 %a, i64 %b) {
 ; CHECK-LABEL: kstsa16:
 ; CHECK:       # %bb.0: # %entry
@@ -1000,6 +1318,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.kstsa16.i64(i64, i64)
+
+define i64 @kstsa32(i64 %a, i64 %b) {
+; CHECK-LABEL: kstsa32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    kstsa32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.kstsa32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.kstsa32.i64(i64, i64)
 
 define i64 @ksub8(i64 %a, i64 %b) {
 ; CHECK-LABEL: ksub8:
@@ -1024,6 +1354,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.ksub16.i64(i64, i64)
+
+define i64 @ksub32(i64 %a, i64 %b) {
+; CHECK-LABEL: ksub32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    ksub32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.ksub32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.ksub32.i64(i64, i64)
 
 define i64 @ksubh(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: ksubh:
@@ -1192,12 +1534,26 @@ declare i64 @llvm.riscv.radd8.i64(i64, i64)
 define i64 @radd16(i64 %a, i64 %b) {
 ; CHECK-LABEL: radd16:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    radd8 a0, a0, a1
+; CHECK-NEXT:    radd16 a0, a0, a1
 ; CHECK-NEXT:    ret
 entry:
-  %0 = tail call i64 @llvm.riscv.radd8.i64(i64 %a, i64 %b)
+  %0 = tail call i64 @llvm.riscv.radd16.i64(i64 %a, i64 %b)
   ret i64 %0
 }
+
+declare i64 @llvm.riscv.radd16.i64(i64, i64)
+
+define i64 @radd32(i64 %a, i64 %b) {
+; CHECK-LABEL: radd32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    radd32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.radd32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.radd32.i64(i64, i64)
 
 define i64 @raddw(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: raddw:
@@ -1225,6 +1581,18 @@ entry:
 
 declare i64 @llvm.riscv.rcras16.i64(i64, i64)
 
+define i64 @rcras32(i64 %a, i64 %b) {
+; CHECK-LABEL: rcras32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    rcras32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.rcras32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.rcras32.i64(i64, i64)
+
 define i64 @rcrsa16(i64 %a, i64 %b) {
 ; CHECK-LABEL: rcrsa16:
 ; CHECK:       # %bb.0: # %entry
@@ -1236,6 +1604,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.rcrsa16.i64(i64, i64)
+
+define i64 @rcrsa32(i64 %a, i64 %b) {
+; CHECK-LABEL: rcrsa32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    rcrsa32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.rcrsa32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.rcrsa32.i64(i64, i64)
 
 define i64 @rstas16(i64 %a, i64 %b) {
 ; CHECK-LABEL: rstas16:
@@ -1249,6 +1629,18 @@ entry:
 
 declare i64 @llvm.riscv.rstas16.i64(i64, i64)
 
+define i64 @rstas32(i64 %a, i64 %b) {
+; CHECK-LABEL: rstas32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    rstas32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.rstas32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.rstas32.i64(i64, i64)
+
 define i64 @rstsa16(i64 %a, i64 %b) {
 ; CHECK-LABEL: rstsa16:
 ; CHECK:       # %bb.0: # %entry
@@ -1260,6 +1652,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.rstsa16.i64(i64, i64)
+
+define i64 @rstsa32(i64 %a, i64 %b) {
+; CHECK-LABEL: rstsa32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    rstsa32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.rstsa32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.rstsa32.i64(i64, i64)
 
 define i64 @rsub8(i64 %a, i64 %b) {
 ; CHECK-LABEL: rsub8:
@@ -1284,6 +1688,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.rsub16.i64(i64, i64)
+
+define i64 @rsub32(i64 %a, i64 %b) {
+; CHECK-LABEL: rsub32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    rsub32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.rsub32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.rsub32.i64(i64, i64)
 
 define i64 @rsubw(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: rsubw:
@@ -1396,6 +1812,16 @@ entry:
   ret i64 %0
 }
 
+define i64 @slli8(i64 %a, i32 signext %b) {
+; CHECK-LABEL: slli8:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    slli8 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.sll8.i64.i64(i64 %a, i64 1)
+  ret i64 %0
+}
+
 declare i64 @llvm.riscv.sll8.i64.i64(i64, i64)
 
 define i64 @sll16(i64 %a, i32 signext %b) {
@@ -1410,6 +1836,17 @@ entry:
   %0 = tail call i64 @llvm.riscv.sll16.i64.i64(i64 %a, i64 %conv)
   ret i64 %0
 }
+
+define i64 @slli16(i64 %a, i32 signext %b) {
+; CHECK-LABEL: slli16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    slli16 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.sll16.i64.i64(i64 %a, i64 1)
+  ret i64 %0
+}
+
 
 declare i64 @llvm.riscv.sll16.i64.i64(i64, i64)
 
@@ -1473,6 +1910,18 @@ entry:
 
 declare i64 @llvm.riscv.smbb16.i64.i64(i64, i64)
 
+define i64 @smbb32(i64 %a, i64 %b) {
+; CHECK-LABEL: smbb32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    smbb32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.smbb32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.smbb32.i64(i64, i64)
+
 define i64 @smbt16(i64 %a, i64 %b) {
 ; CHECK-LABEL: smbt16:
 ; CHECK:       # %bb.0: # %entry
@@ -1484,6 +1933,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.smbt16.i64.i64(i64, i64)
+
+define i64 @smbt32(i64 %a, i64 %b) {
+; CHECK-LABEL: smbt32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    smbt32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.smbt32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.smbt32.i64(i64, i64)
 
 define i64 @smtt16(i64 %a, i64 %b) {
 ; CHECK-LABEL: smtt16:
@@ -1497,6 +1958,18 @@ entry:
 
 declare i64 @llvm.riscv.smtt16.i64.i64(i64, i64)
 
+define i64 @smtt32(i64 %a, i64 %b) {
+; CHECK-LABEL: smtt32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    smtt32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.smtt32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.smtt32.i64(i64, i64)
+
 define i64 @smds(i64 %a, i64 %b) {
 ; CHECK-LABEL: smds:
 ; CHECK:       # %bb.0: # %entry
@@ -1508,6 +1981,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.smds.i64.i64(i64, i64)
+
+define i64 @smds32(i64 %a, i64 %b) {
+; CHECK-LABEL: smds32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    smds32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.smds32.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.smds32.i64.i64(i64, i64)
 
 define i64 @smdrs(i64 %a, i64 %b) {
 ; CHECK-LABEL: smdrs:
@@ -1521,6 +2006,18 @@ entry:
 
 declare i64 @llvm.riscv.smdrs.i64.i64(i64, i64)
 
+define i64 @smdrs32(i64 %a, i64 %b) {
+; CHECK-LABEL: smdrs32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    smdrs32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.smdrs32.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.smdrs32.i64.i64(i64, i64)
+
 define i64 @smxds(i64 %a, i64 %b) {
 ; CHECK-LABEL: smxds:
 ; CHECK:       # %bb.0: # %entry
@@ -1532,6 +2029,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.smxds.i64.i64(i64, i64)
+
+define i64 @smxds32(i64 %a, i64 %b) {
+; CHECK-LABEL: smxds32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    smxds32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.smxds32.i64.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.smxds32.i64.i64(i64, i64)
 
 define i64 @smin8(i64 %a, i64 %b) {
 ; CHECK-LABEL: smin8:
@@ -1657,6 +2166,16 @@ entry:
   ret i64 %0
 }
 
+define i64 @srai8(i64 %a, i32 signext %b) {
+; CHECK-LABEL: srai8:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai8 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.sra8.i64.i64(i64 %a, i64 1)
+  ret i64 %0
+}
+
 declare i64 @llvm.riscv.sra8.i64.i64(i64, i64)
 
 define i64 @sra8_u(i64 %a, i32 signext %b) {
@@ -1669,6 +2188,16 @@ define i64 @sra8_u(i64 %a, i32 signext %b) {
 entry:
   %conv = zext i32 %b to i64
   %0 = tail call i64 @llvm.riscv.sra8.u.i64.i64(i64 %a, i64 %conv)
+  ret i64 %0
+}
+
+define i64 @srai8_u(i64 %a, i32 signext %b) {
+; CHECK-LABEL: srai8_u:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai8.u a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.sra8.u.i64.i64(i64 %a, i64 1)
   ret i64 %0
 }
 
@@ -1687,6 +2216,16 @@ entry:
   ret i64 %0
 }
 
+define i64 @srai16(i64 %a, i32 signext %b) {
+; CHECK-LABEL: srai16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai16 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.sra16.i64.i64(i64 %a, i64 1)
+  ret i64 %0
+}
+
 declare i64 @llvm.riscv.sra16.i64.i64(i64, i64)
 
 define i64 @sra16_u(i64 %a, i32 signext %b) {
@@ -1699,6 +2238,16 @@ define i64 @sra16_u(i64 %a, i32 signext %b) {
 entry:
   %conv = zext i32 %b to i64
   %0 = tail call i64 @llvm.riscv.sra16.u.i64.i64(i64 %a, i64 %conv)
+  ret i64 %0
+}
+
+define i64 @srai16_u(i64 %a, i32 signext %b) {
+; CHECK-LABEL: srai16_u:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srai16.u a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.sra16.u.i64.i64(i64 %a, i64 1)
   ret i64 %0
 }
 
@@ -1717,6 +2266,16 @@ entry:
   ret i64 %0
 }
 
+define i64 @srli8(i64 %a, i32 signext %b) {
+; CHECK-LABEL: srli8:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srli8 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.srl8.i64.i64(i64 %a, i64 1)
+  ret i64 %0
+}
+
 declare i64 @llvm.riscv.srl8.i64.i64(i64, i64)
 
 define i64 @srl8_u(i64 %a, i32 signext %b) {
@@ -1729,6 +2288,16 @@ define i64 @srl8_u(i64 %a, i32 signext %b) {
 entry:
   %conv = zext i32 %b to i64
   %0 = tail call i64 @llvm.riscv.srl8.u.i64.i64(i64 %a, i64 %conv)
+  ret i64 %0
+}
+
+define i64 @srli8_u(i64 %a, i32 signext %b) {
+; CHECK-LABEL: srli8_u:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srli8.u a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.srl8.u.i64.i64(i64 %a, i64 1)
   ret i64 %0
 }
 
@@ -1747,6 +2316,16 @@ entry:
   ret i64 %0
 }
 
+define i64 @srli16(i64 %a, i32 signext %b) {
+; CHECK-LABEL: srli16:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srli16 a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.srl16.i64.i64(i64 %a, i64 1)
+  ret i64 %0
+}
+
 declare i64 @llvm.riscv.srl16.i64.i64(i64, i64)
 
 define i64 @srl16_u(i64 %a, i32 signext %b) {
@@ -1759,6 +2338,16 @@ define i64 @srl16_u(i64 %a, i32 signext %b) {
 entry:
   %conv = zext i32 %b to i64
   %0 = tail call i64 @llvm.riscv.srl16.u.i64.i64(i64 %a, i64 %conv)
+  ret i64 %0
+}
+
+define i64 @srli16_u(i64 %a, i32 signext %b) {
+; CHECK-LABEL: srli16_u:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    srli16.u a0, a0, 1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.srl16.u.i64.i64(i64 %a, i64 1)
   ret i64 %0
 }
 
@@ -1776,6 +2365,18 @@ entry:
 
 declare i64 @llvm.riscv.stas16.i64(i64, i64)
 
+define i64 @stas32(i64 %a, i64 %b) {
+; CHECK-LABEL: stas32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    stas32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.stas32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.stas32.i64(i64, i64)
+
 define i64 @stsa16(i64 %a, i64 %b) {
 ; CHECK-LABEL: stsa16:
 ; CHECK:       # %bb.0: # %entry
@@ -1787,6 +2388,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.stsa16.i64(i64, i64)
+
+define i64 @stsa32(i64 %a, i64 %b) {
+; CHECK-LABEL: stsa32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    stsa32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.stsa32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.stsa32.i64(i64, i64)
 
 define i64 @sub8(i64 %a, i64 %b) {
 ; CHECK-LABEL: sub8:
@@ -1811,6 +2424,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.sub16.i64(i64, i64)
+
+define i64 @sub32(i64 %a, i64 %b) {
+; CHECK-LABEL: sub32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    sub32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.sub32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.sub32.i64(i64, i64)
 
 define i64 @sunpkd810(i64 %a) {
 ; CHECK-LABEL: sunpkd810:
@@ -2004,6 +2629,18 @@ entry:
 
 declare i64 @llvm.riscv.ukadd16.i64(i64, i64)
 
+define i64 @ukadd32(i64 %a, i64 %b) {
+; CHECK-LABEL: ukadd32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    ukadd32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.ukadd32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.ukadd32.i64(i64, i64)
+
 define i64 @ukaddh(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: ukaddh:
 ; CHECK:       # %bb.0: # %entry
@@ -2044,6 +2681,18 @@ entry:
 
 declare i64 @llvm.riscv.ukcras16.i64(i64, i64)
 
+define i64 @ukcras32(i64 %a, i64 %b) {
+; CHECK-LABEL: ukcras32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    ukcras32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.ukcras32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.ukcras32.i64(i64, i64)
+
 define i64 @ukcrsa16(i64 %a, i64 %b) {
 ; CHECK-LABEL: ukcrsa16:
 ; CHECK:       # %bb.0: # %entry
@@ -2055,6 +2704,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.ukcrsa16.i64(i64, i64)
+
+define i64 @ukcrsa32(i64 %a, i64 %b) {
+; CHECK-LABEL: ukcrsa32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    ukcrsa32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.ukcrsa32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.ukcrsa32.i64(i64, i64)
 
 define i64 @ukstas16(i64 %a, i64 %b) {
 ; CHECK-LABEL: ukstas16:
@@ -2068,6 +2729,18 @@ entry:
 
 declare i64 @llvm.riscv.ukstas16.i64(i64, i64)
 
+define i64 @ukstas32(i64 %a, i64 %b) {
+; CHECK-LABEL: ukstas32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    ukstas32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.ukstas32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.ukstas32.i64(i64, i64)
+
 define i64 @ukstsa16(i64 %a, i64 %b) {
 ; CHECK-LABEL: ukstsa16:
 ; CHECK:       # %bb.0: # %entry
@@ -2079,6 +2752,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.ukstsa16.i64(i64, i64)
+
+define i64 @ukstsa32(i64 %a, i64 %b) {
+; CHECK-LABEL: ukstsa32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    ukstsa32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.ukstsa32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.ukstsa32.i64(i64, i64)
 
 define i64 @uksub8(i64 %a, i64 %b) {
 ; CHECK-LABEL: uksub8:
@@ -2103,6 +2788,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.uksub16.i64(i64, i64)
+
+define i64 @uksub32(i64 %a, i64 %b) {
+; CHECK-LABEL: uksub32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    uksub32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.uksub32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.uksub32.i64(i64, i64)
 
 define i64 @uksubh(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: uksubh:
@@ -2215,12 +2912,26 @@ declare i64 @llvm.riscv.uradd8.i64(i64, i64)
 define i64 @uradd16(i64 %a, i64 %b) {
 ; CHECK-LABEL: uradd16:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    uradd8 a0, a0, a1
+; CHECK-NEXT:    uradd16 a0, a0, a1
 ; CHECK-NEXT:    ret
 entry:
-  %0 = tail call i64 @llvm.riscv.uradd8.i64(i64 %a, i64 %b)
+  %0 = tail call i64 @llvm.riscv.uradd16.i64(i64 %a, i64 %b)
   ret i64 %0
 }
+
+declare i64 @llvm.riscv.uradd16.i64(i64, i64)
+
+define i64 @uradd32(i64 %a, i64 %b) {
+; CHECK-LABEL: uradd32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    uradd32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.uradd32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.uradd32.i64(i64, i64)
 
 define i64 @uraddw(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: uraddw:
@@ -2252,6 +2963,18 @@ entry:
 
 declare i64 @llvm.riscv.urcras16.i64(i64, i64)
 
+define i64 @urcras32(i64 %a, i64 %b) {
+; CHECK-LABEL: urcras32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    urcras32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.urcras32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.urcras32.i64(i64, i64)
+
 define i64 @urcrsa16(i64 %a, i64 %b) {
 ; CHECK-LABEL: urcrsa16:
 ; CHECK:       # %bb.0: # %entry
@@ -2263,6 +2986,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.urcrsa16.i64(i64, i64)
+
+define i64 @urcrsa32(i64 %a, i64 %b) {
+; CHECK-LABEL: urcrsa32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    urcrsa32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.urcrsa32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.urcrsa32.i64(i64, i64)
 
 define i64 @urstas16(i64 %a, i64 %b) {
 ; CHECK-LABEL: urstas16:
@@ -2276,6 +3011,18 @@ entry:
 
 declare i64 @llvm.riscv.urstas16.i64(i64, i64)
 
+define i64 @urstas32(i64 %a, i64 %b) {
+; CHECK-LABEL: urstas32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    urstas32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.urstas32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.urstas32.i64(i64, i64)
+
 define i64 @urstsa16(i64 %a, i64 %b) {
 ; CHECK-LABEL: urstsa16:
 ; CHECK:       # %bb.0: # %entry
@@ -2287,6 +3034,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.urstsa16.i64(i64, i64)
+
+define i64 @urstsa32(i64 %a, i64 %b) {
+; CHECK-LABEL: urstsa32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    urstsa32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.urstsa32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.urstsa32.i64(i64, i64)
 
 define i64 @ursub8(i64 %a, i64 %b) {
 ; CHECK-LABEL: ursub8:
@@ -2311,6 +3070,18 @@ entry:
 }
 
 declare i64 @llvm.riscv.ursub16.i64(i64, i64)
+
+define i64 @ursub32(i64 %a, i64 %b) {
+; CHECK-LABEL: ursub32:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    ursub32 a0, a0, a1
+; CHECK-NEXT:    ret
+entry:
+  %0 = tail call i64 @llvm.riscv.ursub32.i64(i64 %a, i64 %b)
+  ret i64 %0
+}
+
+declare i64 @llvm.riscv.ursub32.i64(i64, i64)
 
 define i64 @ursubw(i32 signext %a, i32 signext %b) {
 ; CHECK-LABEL: ursubw:

--- a/llvm/test/MC/RISCV/rv64zpn-valid.s
+++ b/llvm/test/MC/RISCV/rv64zpn-valid.s
@@ -10,14 +10,14 @@
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 
 # With Zpn extension:
-# RUN: llvm-mc -triple=riscv64 -show-encoding --mattr=+experimental-zpn %s \
+# RUN: llvm-mc -triple=riscv64 -show-encoding --mattr=+experimental-zpn,+experimental-zpsfoperand %s \
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
 # RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
 # RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
-# RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+experimental-zpn %s \
+# RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+experimental-zpn,+experimental-zpsfoperand %s \
 # RUN:        | llvm-objdump -d --mattr=+experimental-p - \
 # RUN:        | FileCheck %s --check-prefix=CHECK-INST
-# RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+experimental-zpn %s \
+# RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+experimental-zpn,+experimental-zpsfoperand %s \
 # RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN
 
 # RV64P only
@@ -380,6 +380,12 @@ kdmatt16 a0, a1, a2
 
 # 32-bit Multiply
 
+# CHECK-INST: smbb32 a0, a1, a2
+# CHECK-ENCODING: [0x77,0x95,0xc5,0xe0]
+# CHECK-ERROR: instruction requires the following: 'Zpn' (Normal 'P' Instructions)
+# CHECK-UNKNOWN: 77 95 c5 e0 <unknown>
+smbb32 a0, a1, a2
+
 # CHECK-INST: smbt32 a0, a1, a2
 # CHECK-ENCODING: [0x77,0xa5,0xc5,0x18]
 # CHECK-ERROR: instruction requires the following: 'Zpn' (Normal 'P' Instructions)
@@ -423,6 +429,12 @@ kmda32 a0, a1, a2
 # CHECK-ERROR: instruction requires the following: 'Zpn' (Normal 'P' Instructions)
 # CHECK-UNKNOWN: 77 a5 c5 3a <unknown>
 kmxda32 a0, a1, a2
+
+# CHECK-INST: kmada32 a0, a1, a2
+# CHECK-ENCODING: [0x77,0x95,0xc5,0x94]
+# CHECK-ERROR: instruction requires the following: 'Zpn' (Normal 'P' Instructions)
+# CHECK-UNKNOWN: 77 95 c5 94 <unknown>
+kmada32 a0, a1, a2
 
 # CHECK-INST: kmaxda32 a0, a1, a2
 # CHECK-ENCODING: [0x77,0xa5,0xc5,0x4a]


### PR DESCRIPTION
add mc/llvm and c intrinsic for smbb32
add llvm/c intrinsic for smbt32/smtt32
intrinsic support for srai16/srai16.u/srli16/srli16.u/slli16
intrinsic support for srai8/srai8.u/srli8/srli8.u/slli8 add intrinsic test for kslli8,kslli16
SIMD 32-bit Add/Subtract Instructions llvm/c intrinsic
SIMD Q15 saturating Multiply Instruction llvm/c intrinsic
32-bit Parallel Multiply & Add Instructions llvm intrinsic